### PR TITLE
Initial prototyping of Scala interfaces

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,4 @@
+/*
+ * Copyright © 2014-2015 Typesafe, Inc. All rights reserved. No information contained herein may be reproduced or
+ * transmitted in any form or by any means without the express written permission of Typesafe, Inc.
+ */

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,12 @@ lazy val root = project
 lazy val conductrBundleLib = project
   .in(file("conductr-bundle-lib"))
   .dependsOn(testLib % "test->compile")
-  
+
+lazy val scalaConductRBundleLib = project
+  .in(file("scala-conductr-bundle-lib"))
+  .dependsOn(conductrBundleLib)
+  .dependsOn(testLib % "test->compile")
+
 lazy val testLib = project
   .in(file("test-lib"))
   

--- a/conductr-bundle-lib/src/main/java/com/typesafe/conductr/bundlelib/Env.java
+++ b/conductr-bundle-lib/src/main/java/com/typesafe/conductr/bundlelib/Env.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2014-2015 Typesafe, Inc. All rights reserved. No information contained herein may be reproduced or
+ * transmitted in any form or by any means without the express written permission of Typesafe, Inc.
+ */
+
+package com.typesafe.conductr.bundlelib;
+
+/**
+ * ConductR environment vars.
+ */
+public class Env {
+    private Env() {
+    }
+
+    /**
+     * The bundle id of the current bundle
+     */
+    public static final String BUNDLE_ID = System.getenv("BUNDLE_ID");
+
+    /**
+     * The URL associated with reporting status back to ConductR
+     */
+    public static final String CONDUCTR_STATUS = System.getenv("CONDUCTR_STATUS");
+
+    /**
+     * The URL associated with locating services known to ConductR
+     */
+    public static final String SERVICE_LOCATOR = System.getenv("SERVICE_LOCATOR");
+}

--- a/conductr-bundle-lib/src/main/java/com/typesafe/conductr/bundlelib/LocationService.java
+++ b/conductr-bundle-lib/src/main/java/com/typesafe/conductr/bundlelib/LocationService.java
@@ -7,7 +7,7 @@ package com.typesafe.conductr.bundlelib;
 
 import java.io.IOException;
 import java.net.URL;
-import static com.typesafe.conductr.bundlelib.Common.*;
+import static com.typesafe.conductr.bundlelib.Env.*;
 
 /**
  * LocationService used to look up services using the Typesafe ConductR Service Locator.
@@ -16,8 +16,6 @@ public class LocationService {
 
     private LocationService() {
     }
-
-    private static final String SERVICE_LOCATOR = System.getenv("SERVICE_LOCATOR");
 
     /**
      * Create the HttpPayload necessary to look up a service by name.
@@ -28,7 +26,8 @@ public class LocationService {
      * All other response codes are considered illegal.
      *
      * @param serviceName The name of the service
-     * @return An HttpPayload describing how to do the service lookup
+     * @return An HttpPayload describing how to do the service lookup or null if
+     * this program is not running within ConductR
      * @throws IOException
      */
     public static HttpPayload createLookupPayload(String serviceName) throws IOException {

--- a/conductr-bundle-lib/src/main/java/com/typesafe/conductr/bundlelib/StatusService.java
+++ b/conductr-bundle-lib/src/main/java/com/typesafe/conductr/bundlelib/StatusService.java
@@ -7,7 +7,7 @@ package com.typesafe.conductr.bundlelib;
 
 import java.io.IOException;
 import java.net.URL;
-import static com.typesafe.conductr.bundlelib.Common.*;
+import static com.typesafe.conductr.bundlelib.Env.*;
 
 /**
  * StatusService used to communicate the bundle status to the Typesafe ConductR Status Server.
@@ -17,14 +17,13 @@ public class StatusService {
     private StatusService() {
     }
 
-    private static final String CONDUCTR_STATUS = System.getenv("CONDUCTR_STATUS");
-
     /**
      * Create the HttpPayload necessary to signal that a bundle has started.
      *
      * Any 2xx response code is considered a success. Any other response code is considered a failure.
      *
-     * @return An HttpPayload describing how to signal that a bundle has started
+     * @return An HttpPayload describing how to signal that a bundle has started or null if
+     * this program is not running within ConductR
      * @throws IOException
      */
     public static HttpPayload createSignalStartedPayload() throws IOException {

--- a/scala-conductr-bundle-lib/build.sbt
+++ b/scala-conductr-bundle-lib/build.sbt
@@ -3,12 +3,4 @@
  * transmitted in any form or by any means without the express written permission of Typesafe, Inc.
  */
 
-package com.typesafe.conductr.bundlelib;
-
-class Common {
-    private Common() {
-    }
-
-    static final String BUNDLE_ID = System.getenv("BUNDLE_ID");
-    static final String USER_AGENT = "TypesafeConductRBundleLib";
-}
+name := "scala-conductr-bundle-lib"

--- a/scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/scala/ConnectionHandler.scala
+++ b/scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/scala/ConnectionHandler.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2014-2015 Typesafe, Inc. All rights reserved. No information contained herein may be reproduced or
+ * transmitted in any form or by any means without the express written permission of Typesafe, Inc.
+ */
+
+package com.typesafe.conductr.bundlelib.scala
+
+import java.io.IOException
+import java.net.HttpURLConnection
+
+import com.typesafe.conductr.bundlelib.HttpPayload
+
+import scala.concurrent.{ blocking, Future, ExecutionContext }
+import scala.util.{ Failure, Success, Try }
+
+/**
+ * Handles the JDK HttpURLConnection requests and responses
+ */
+object ConnectionHandler {
+  private final val UserAgent = "TypesafeConductRBundleLib"
+
+  /**
+   * Make a request to a ConductR service given a payload. Returns a future of an option. If there is some response
+   * then a Some() will convey the result, otherwise None indicates that this program is not running in the context
+   * of ConductR.
+   */
+  def withConnectedRequest[T](
+    payload: Option[HttpPayload])(thunk: HttpURLConnection => Option[T])(implicit ec: ExecutionContext): Future[Option[T]] =
+
+    payload.fold[Future[Option[T]]](Future.successful(None)) { p =>
+      Future {
+        Try(p.getUrl.openConnection) match {
+          case Success(con: HttpURLConnection) =>
+            con.setRequestMethod(p.getRequestMethod)
+            con.setInstanceFollowRedirects(p.getFollowRedirects)
+            con.setRequestProperty("User-Agent", UserAgent)
+            blocking {
+              con.connect()
+              try {
+                thunk(con)
+              } finally {
+                con.disconnect()
+              }
+            }
+          case Success(con) =>
+            throw new IOException(s"Unexpected type of connection $con for $p")
+          case Failure(e) =>
+            throw new IOException(s"Connection failed for $p", e)
+        }
+      }
+    }
+
+}

--- a/scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/scala/LocationService.scala
+++ b/scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/scala/LocationService.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2014-2015 Typesafe, Inc. All rights reserved. No information contained herein may be reproduced or
+ * transmitted in any form or by any means without the express written permission of Typesafe, Inc.
+ */
+
+package com.typesafe.conductr.bundlelib.scala
+
+import java.io.IOException
+import java.net.URL
+
+import com.typesafe.conductr.bundlelib.{ LocationService => JavaLocationService }
+import com.typesafe.conductr.bundlelib.scala.ConnectionHandler.withConnectedRequest
+
+import scala.concurrent._
+
+/**
+ * LocationService used to look up services using the Typesafe ConductR Service Locator.
+ */
+object LocationService {
+
+  /**
+   * Look up a service by service name. Service names correspond to those declared in a Bundle
+   * component's endpoint data structure i.e. within a bundle's bundle.conf.
+   *
+   * Returns some URL representing the service or None if the service is not found or if this
+   * program is not running in the context of ConductR.
+   */
+  def lookup(serviceName: String)(implicit ec: ExecutionContext): Future[Option[URL]] =
+    withConnectedRequest(Option(JavaLocationService.createLookupPayload(serviceName))) { con =>
+      con.getResponseCode match {
+        case 307 =>
+          Option(con.getHeaderField("Location"))
+            .map(new URL(_))
+            .orElse(throw new IOException("Missing Location header"))
+        case _ =>
+          throw new IOException(s"Illegal response code ${con.getResponseCode}")
+      }
+    }
+
+}

--- a/scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/scala/StatusService.scala
+++ b/scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/scala/StatusService.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2014-2015 Typesafe, Inc. All rights reserved. No information contained herein may be reproduced or
+ * transmitted in any form or by any means without the express written permission of Typesafe, Inc.
+ */
+
+package com.typesafe.conductr.bundlelib.scala
+
+import java.io.IOException
+
+import com.typesafe.conductr.bundlelib.{ StatusService => JavaStatusService }
+import com.typesafe.conductr.bundlelib.scala.ConnectionHandler.withConnectedRequest
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+/**
+ * StatusService used to communicate the bundle status to the Typesafe ConductR Status Server.
+ */
+object StatusService {
+
+  /**
+   * Signal that the bundle has started or exit the JVM if it fails. If the bundle fails to communicate that
+   * it has started it will eventually be killed by the ConductR.
+   *
+   * This will exit the JVM if it fails with exit code 70 (EXIT_SOFTWARE, Internal Software Error,
+   * as defined in BSD sysexits.h).
+   *
+   * The returned future will complete successfully if the ConductR acknowledges the start signal.
+   * A Future of None will be returned if this program is not running in the context of ConductR.
+   */
+  def signalStartedOrExit()(implicit ec: ExecutionContext): Future[Option[Unit]] =
+    signalStarted().recover {
+      case _: Throwable => Some(System.exit(70))
+    }
+
+  /**
+   * Signal that the bundle has started or throw IOException if it fails. If the bundle fails to communicate that
+   * it has started it will eventually be killed by the ConductR.
+   *
+   * The returned future will complete successfully if the ConductR acknowledges the start signal.
+   * A Future of None will be returned if this program is not running in the context of ConductR.
+   */
+  def signalStarted()(implicit ec: ExecutionContext): Future[Option[Unit]] =
+    withConnectedRequest(Option(JavaStatusService.createSignalStartedPayload())) { con =>
+      val responseCode = con.getResponseCode
+      if (responseCode < 200 || responseCode >= 300)
+        throw new IOException("Illegal response code " + responseCode)
+      Some(())
+    }
+}


### PR DESCRIPTION
I've gone for a pure Scala/JDK dependent bundle lib initially as I see this as our base offering other than having the user manually create requests.

@viktorklang Further to our chats last night, I'm exploring an async interface backed by the JDK blocking approach. We actually already have pure Scala apps to host in ConductR, hence this approach.
