### PR TITLE
LocationService now returns caching information

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,42 @@ When processing the http response you should check for the following http status
 * xxx - failure - anything else constitutes an error and you should cause the bundle component to exit
 
 You should also prepare for timing out on a request and exit the bundle component if this occurs.
+
+## scala-conductr-bundle-lib
+
+This library provides a reactive API using only Scala and Java types. There are no dependencies other than `conductr-bundle-lib`, Scala and the JDK and it is designed to be used where there is no Akka or Play dependency in your application.
+
+As with `conductr-bundle-lib` there is are two services:
+
+* LocationService
+* StatusService
+
+Please read the section on `conductr-bundle-lib` for an overview of these services.
+
+### LocationService
+
+The following code illustrates how a service may be located in place of creating and dispatching your own payload:
+
+```scala
+// This will require an implicit ExecutionContext
+// as "service" is returned as a Future.
+val service = LocationService.lookup("/someservice")
+```
+
+`service` is typed `Future[Option[URL, Option[FiniteDuration]]` meaning that an optional response will be returned at some time in the future. Supposing that this lookup is made during the initialisation of your program, the service you're looking for may not exist. However calling the same function later on may yield the service. This is because services can come and go.
+
+The service response constitutes a URL that describes its location along with an optional duration indicating how long the URL may be cached for. A value of `None` indicates that the service should not be cached.
+
+### StatusService
+
+The following code illustrates how your bundle component should register its initial health with ConductR. Calling this function is to be done in place of creating and dispatching your own payload:
+
+```scala
+// This will require an implicit ExecutionContext
+// as the signalling is performed asynchronously.
+StatusService.signalStarted()
+```
+
+In general, the return value of `signalStartedOrExit` is not used and your program proceeds. If ConductR fails to reply, or replies with an error status then this bundle component will exit.
+
+In case you are interested, the function returns a `Future[Option[Unit]]` where a future `Some(())` indicates that ConductR has successfully acknowledged the startup signal. A future of `None` indicates that the bundle has not been started by ConductR.

--- a/scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/scala/LocationService.scala
+++ b/scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/scala/LocationService.scala
@@ -12,6 +12,7 @@ import com.typesafe.conductr.bundlelib.{ LocationService => JavaLocationService 
 import com.typesafe.conductr.bundlelib.scala.ConnectionHandler.withConnectedRequest
 
 import scala.concurrent._
+import scala.concurrent.duration._
 
 /**
  * LocationService used to look up services using the Typesafe ConductR Service Locator.
@@ -23,14 +24,18 @@ object LocationService {
    * component's endpoint data structure i.e. within a bundle's bundle.conf.
    *
    * Returns some URL representing the service or None if the service is not found or if this
-   * program is not running in the context of ConductR.
+   * program is not running in the context of ConductR. An optional maxAge duration is also returned
+   * indicating that the value may be cached for by the caller up to this period of time.
    */
-  def lookup(serviceName: String)(implicit ec: ExecutionContext): Future[Option[URL]] =
+  def lookup(serviceName: String)(implicit ec: ExecutionContext): Future[Option[(URL, Option[FiniteDuration])]] =
     withConnectedRequest(Option(JavaLocationService.createLookupPayload(serviceName))) { con =>
       con.getResponseCode match {
         case 307 =>
           Option(con.getHeaderField("Location"))
-            .map(new URL(_))
+            .map { location =>
+              val url = new URL(location)
+              url -> None // FIXME: Need to interpret max-age here.
+            }
             .orElse(throw new IOException("Missing Location header"))
         case 404 =>
           None

--- a/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/LocationServiceSpecWithEnv.scala
+++ b/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/LocationServiceSpecWithEnv.scala
@@ -24,8 +24,8 @@ class LocationServiceSpecWithEnv extends AkkaUnitTest("LocationServiceSpecWithEn
       import system.dispatcher
       val serviceUrl = "http://service_interface:4711/known"
       withServerWithKnownService(serviceUrl) {
-        val url = LocationService.lookup("/known")
-        Await.result(url, timeout.duration) should be(Some(new URL(serviceUrl)))
+        val service = LocationService.lookup("/known")
+        Await.result(service, timeout.duration) should be(Some(new URL(serviceUrl) -> None))
       }
     }
 
@@ -33,8 +33,8 @@ class LocationServiceSpecWithEnv extends AkkaUnitTest("LocationServiceSpecWithEn
       import system.dispatcher
       val serviceUrl = "http://service_interface:4711/known"
       withServerWithKnownService(serviceUrl) {
-        val url = LocationService.lookup("/unknown")
-        Await.result(url, timeout.duration) should be(None)
+        val service = LocationService.lookup("/unknown")
+        Await.result(service, timeout.duration) should be(None)
       }
     }
   }


### PR DESCRIPTION
...almost anyhow... there's a FIXME to actually read the Cache-Control header, but the API is of immediate concern.

Documentation is also provided for the scala lib.

Issue in relation to the FIXME: https://github.com/typesafehub/conductr-bundle-lib/issues/8
