### PR TITLE
URLs should be URIs for the service locater Location

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Two services are covered by this library:
 
 ### Location Service
 
-ConductR's location service is able to respond with a URL declaring where a given service (as named by a bundle component's endpoint) resides. The http payload can be constructed as follows:
+ConductR's location service is able to respond with a URI declaring where a given service (as named by a bundle component's endpoint) resides. The http payload can be constructed as follows:
 
 ```java
 HttpPayload payload = LocationService.createLookupPayload("/someservice")
@@ -34,7 +34,7 @@ The `HttpPayload` object may then be queried for elements that will help you mak
 
 When processing the http response you should check for the following http status codes:
 
-* 308 - permanent redirect - the service can be found at the location indicated by the `Location` header
+* 307 - temporary redirect - the service can be found at the location indicated by the `Location` header. `Cache-Control` may also be supplied to indicate how long the location may be cached for.
 * 404 - not found - the service cannot be located at this time
 
 You should also prepare for timing out on a request and process as per a 404.
@@ -94,20 +94,20 @@ If the service you require is not HTTP based then you may use the `LocationServi
 val service = LocationService.lookup("/someservice")
 ```
 
-`service` is typed `Future[Option[URL, Option[FiniteDuration]]` meaning that an optional response will be returned at some time in the future. Supposing that this lookup is made during the initialisation of your program, the service you're looking for may not exist. However calling the same function later on may yield the service. This is because services can come and go.
+`service` is typed `Future[Option[URI, Option[FiniteDuration]]` meaning that an optional response will be returned at some time in the future. Supposing that this lookup is made during the initialisation of your program, the service you're looking for may not exist. However calling the same function later on may yield the service. This is because services can come and go.
 
-The service response constitutes a URL that describes its location along with an optional duration indicating how long the URL may be cached for. A value of `None` indicates that the service should not be cached.
+The service response constitutes a URI that describes its location along with an optional duration indicating how long the URI may be cached for. A value of `None` indicates that the service should not be cached.
 
 #### Static service lookup
 
 Some bundle components cannot proceed with their initialisation unless the service can be located. We encourage you to re-factor these components so that they look up services at the time when they are required, given that services can come and go. However if you are somehow stuck with this style of code then we offer a utility that causes an exit if the lookup results in no service being found:
 
 ```scala
-val default = new URL("http://127.0.0.1:9000")
-val url = LocationService.lookup("/someservice").map(LocationService.getUrlOrExit(default))
+val default = new URI("http://127.0.0.1:9000")
+val url = LocationService.lookup("/someservice").map(LocationService.getUriOrExit(default))
 ```
 
-Note that the above returns a `Future[URL]` and it will exit in the case of ConductR running and the lookup failing. If ConductR is not running and the lookup fails then the `default` value will be returned.
+Note that the above returns a `Future[URI]` and it will exit in the case of ConductR running and the lookup failing. If ConductR is not running and the lookup fails then the `default` value will be returned.
 
 ### StatusService
 

--- a/conductr-bundle-lib/src/main/java/com/typesafe/conductr/bundlelib/LocationService.java
+++ b/conductr-bundle-lib/src/main/java/com/typesafe/conductr/bundlelib/LocationService.java
@@ -21,7 +21,8 @@ public class LocationService {
      * Create the HttpPayload necessary to look up a service by name.
      *
      * If the service is available and can bee looked up the response for the HTTP request should be
-     * 308 (Permanent Redirect), and the resulting URL to the service is in the "Location" header of the response.
+     * 307 (Temporary Redirect), and the resulting URI to the service is in the "Location" header of the response.
+     * A Cache-Control header may also be returned indicating the maxAge that the location should be cached for.
      * If the service can not be looked up the response should be 404 (Not Found).
      * All other response codes are considered illegal.
      *

--- a/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/LocationServiceSpec.scala
+++ b/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/LocationServiceSpec.scala
@@ -5,7 +5,7 @@
 
 package com.typesafe.conductr.bundlelib.scala
 
-import java.net.URL
+import java.net.URI
 
 import com.typesafe.conductr.AkkaUnitTest
 import scala.concurrent.Await
@@ -19,16 +19,16 @@ class LocationServiceSpec extends AkkaUnitTest("StatusServiceSpec", "akka.loglev
       Await.result(LocationService.lookup("/whatever"), timeout.duration) should be(None)
     }
 
-    "return a default URL when running in development mode" in {
-      val default = new URL("http://127.0.0.1:9000")
-      LocationService.getUrlOrExit(default)(None) should be(default)
+    "return a default URI when running in development mode" in {
+      val default = new URI("http://127.0.0.1:9000")
+      LocationService.getUriOrExit(default)(None) should be(default)
     }
 
-    "return the looked up URL when running in development mode" in {
-      val default = new URL("http://127.0.0.1:9000")
-      val lookedUpUrl = new URL("http://127.0.0.1:9001")
-      val lookedUp: Option[(URL, Option[FiniteDuration])] = Some(lookedUpUrl -> None)
-      LocationService.getUrlOrExit(default)(lookedUp) should be(lookedUpUrl)
+    "return the looked up URI when running in development mode" in {
+      val default = new URI("tcp://127.0.0.1:61616")
+      val lookedUpUri = new URI("tcp://127.0.0.1:10000")
+      val lookedUp: Option[(URI, Option[FiniteDuration])] = Some(lookedUpUri -> None)
+      LocationService.getUriOrExit(default)(lookedUp) should be(lookedUpUri)
     }
   }
 }

--- a/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/LocationServiceSpecWithEnv.scala
+++ b/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/LocationServiceSpecWithEnv.scala
@@ -13,7 +13,7 @@ import akka.stream.FlowMaterializer
 import akka.testkit.TestProbe
 import com.typesafe.conductr.AkkaUnitTest
 import com.typesafe.conductr.bundlelib.Env
-import java.net.{ URL, InetSocketAddress }
+import java.net.{ URI, URL, InetSocketAddress }
 import scala.concurrent.Await
 import scala.util.{ Failure, Success }
 
@@ -22,10 +22,10 @@ class LocationServiceSpecWithEnv extends AkkaUnitTest("LocationServiceSpecWithEn
   "The LocationService functionality in the library" should {
     "be able to look up a named service" in {
       import system.dispatcher
-      val serviceUrl = "http://service_interface:4711/known"
-      withServerWithKnownService(serviceUrl) {
+      val serviceUri = "http://service_interface:4711/known"
+      withServerWithKnownService(serviceUri) {
         val service = LocationService.lookup("/known")
-        Await.result(service, timeout.duration) should be(Some(new URL(serviceUrl) -> None))
+        Await.result(service, timeout.duration) should be(Some(new URI(serviceUri) -> None))
       }
     }
 


### PR DESCRIPTION
...because a) that's what the http spec states; and b) because we want to pass back protocols that URL may not understand e.g. tcp
