### PR TITLE
Idiomatic Scala APIs and removed exit functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Please read the section on `conductr-bundle-lib` for an introduction to these se
 The LocationService looks up service names and processes HTTP's `307` "temporary redirect" responses to return the location of the resolved service (or a `404` if one cannot be found). Many HTTP clients allow the following of redirects, particularly when either of the `HEAD` or `GET` methods are used (other methods may be considered insecure by default). Therefore if the service you are locating is an HTTP one then using a regular HTTP client should require no further work. Here is an example of using the [Dispatch](http://dispatch.databinder.net/Dispatch.html) library:
 
 ```scala
-val svc = Option(LocationService.createLookupPayload("/someservice"))
+val svc = LocationService.createLookupPayload("/someservice")
   .map(_.getUrl.toString)
   .getOrElse("http://127.0.0.1:9000/someservice")
 val svcResp = Http.configure(_.setFollowRedirects(true))(url(svc).OK)

--- a/conductr-bundle-lib/src/main/java/com/typesafe/conductr/bundlelib/Env.java
+++ b/conductr-bundle-lib/src/main/java/com/typesafe/conductr/bundlelib/Env.java
@@ -26,4 +26,11 @@ public class Env {
      * The URL associated with locating services known to ConductR
      */
     public static final String SERVICE_LOCATOR = System.getenv("SERVICE_LOCATOR");
+
+    /**
+     * @return true if ConductR started this process.
+     */
+    public static boolean isRunByConductR() {
+        return BUNDLE_ID != null;
+    }
 }

--- a/conductr-bundle-lib/src/main/java/com/typesafe/conductr/bundlelib/LocationService.java
+++ b/conductr-bundle-lib/src/main/java/com/typesafe/conductr/bundlelib/LocationService.java
@@ -32,11 +32,10 @@ public class LocationService {
      * @throws IOException
      */
     public static HttpPayload createLookupPayload(String serviceName) throws IOException {
-        // if we have no BUNDLE_ID, we are in development mode and do nothing
-        if (BUNDLE_ID == null)
-            return null;
-        else
+        if (isRunByConductR())
             return createLookupPayload(SERVICE_LOCATOR, serviceName);
+        else
+            return null;
     }
 
     static HttpPayload createLookupPayload(String serviceLocator, String serviceName) throws IOException {

--- a/conductr-bundle-lib/src/main/java/com/typesafe/conductr/bundlelib/StatusService.java
+++ b/conductr-bundle-lib/src/main/java/com/typesafe/conductr/bundlelib/StatusService.java
@@ -27,11 +27,10 @@ public class StatusService {
      * @throws IOException
      */
     public static HttpPayload createSignalStartedPayload() throws IOException {
-        // if we have no BUNDLE_ID, we are in development mode and do nothing
-        if (BUNDLE_ID == null)
-            return null;
-        else
+        if (isRunByConductR())
             return createSignalStartedPayload(CONDUCTR_STATUS, BUNDLE_ID);
+        else
+            return null;
     }
 
     static HttpPayload createSignalStartedPayload(String conductrControl, String bundleId) throws IOException {

--- a/conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/HttpPayloadSpec.scala
+++ b/conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/HttpPayloadSpec.scala
@@ -16,9 +16,9 @@ class HttpPayloadSpec extends UnitTest {
       val method = "GET"
       val redirects = true
       val payload = new HttpPayload(url, method, redirects)
-      payload.getFollowRedirects should be(redirects)
-      payload.getRequestMethod should be(method)
-      payload.getUrl should be(url)
+      payload.getFollowRedirects shouldBe redirects
+      payload.getRequestMethod shouldBe method
+      payload.getUrl shouldBe url
     }
   }
 }

--- a/conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/LocationServiceSpec.scala
+++ b/conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/LocationServiceSpec.scala
@@ -11,7 +11,7 @@ class LocationServiceSpec extends UnitTest {
 
   "The LocationService functionality in the library" should {
     "return null when running in development mode" in {
-      LocationService.createLookupPayload("/whatever") should be(null)
+      LocationService.createLookupPayload("/whatever") shouldBe null
     }
   }
 }

--- a/conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/StatusServiceSpec.scala
+++ b/conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/StatusServiceSpec.scala
@@ -12,7 +12,7 @@ class StatusServiceSpec extends UnitTest {
   "The StatusService functionality in the library" should {
 
     "not fail when running in development mode" in {
-      StatusService.createSignalStartedPayload() should be(null)
+      StatusService.createSignalStartedPayload() shouldBe null
     }
   }
 }

--- a/scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/scala/ConnectionHandler.scala
+++ b/scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/scala/ConnectionHandler.scala
@@ -16,7 +16,7 @@ import scala.util.{ Failure, Success, Try }
 /**
  * Handles the JDK HttpURLConnection requests and responses
  */
-object ConnectionHandler {
+private[scala] object ConnectionHandler {
   private final val UserAgent = "TypesafeConductRBundleLib"
 
   /**

--- a/scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/scala/Env.scala
+++ b/scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/scala/Env.scala
@@ -1,0 +1,32 @@
+package com.typesafe.conductr.bundlelib.scala
+
+import com.typesafe.conductr.bundlelib.{ Env => JavaEnv }
+
+/**
+ * Standard ConductR environment vars.
+ */
+object Env {
+  /**
+   * The bundle id of the current bundle
+   */
+  val bundleId: Option[String] =
+    Option(JavaEnv.BUNDLE_ID)
+
+  /**
+   * The URL associated with reporting status back to ConductR
+   */
+  val conductRStatus: Option[String] =
+    Option(JavaEnv.CONDUCTR_STATUS)
+
+  /**
+   * The URL associated with locating services known to ConductR
+   */
+  val serviceLocator: Option[String] =
+    Option(JavaEnv.SERVICE_LOCATOR)
+
+  /**
+   * The universal means of determining whether ConductR started this process
+   */
+  val isRunByConductR: Boolean =
+    JavaEnv.isRunByConductR
+}

--- a/scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/scala/StatusService.scala
+++ b/scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/scala/StatusService.scala
@@ -7,7 +7,7 @@ package com.typesafe.conductr.bundlelib.scala
 
 import java.io.IOException
 
-import com.typesafe.conductr.bundlelib.{ StatusService => JavaStatusService }
+import com.typesafe.conductr.bundlelib.{ StatusService => JavaStatusService, HttpPayload }
 import com.typesafe.conductr.bundlelib.scala.ConnectionHandler.withConnectedRequest
 
 import scala.concurrent.{ ExecutionContext, Future }
@@ -16,6 +16,16 @@ import scala.concurrent.{ ExecutionContext, Future }
  * StatusService used to communicate the bundle status to the Typesafe ConductR Status Server.
  */
 object StatusService {
+  /**
+   * Create the HttpPayload necessary to signal that a bundle has started.
+   *
+   * Any 2xx response code is considered a success. Any other response code is considered a failure.
+   *
+   * @return Some HttpPayload describing how to signal that a bundle has started or None if
+   *         this program is not running within ConductR
+   */
+  def createSignalStartedPayload: Option[HttpPayload] =
+    Option(JavaStatusService.createSignalStartedPayload)
 
   /**
    * Signal that the bundle has started or exit the JVM if it fails.
@@ -39,7 +49,7 @@ object StatusService {
    * A Future of None will be returned if this program is not running in the context of ConductR.
    */
   def signalStarted()(implicit ec: ExecutionContext): Future[Option[Unit]] =
-    withConnectedRequest(Option(JavaStatusService.createSignalStartedPayload())) { con =>
+    withConnectedRequest(createSignalStartedPayload) { con =>
       val responseCode = con.getResponseCode
       if (responseCode < 200 || responseCode >= 300)
         throw new IOException("Illegal response code " + responseCode)

--- a/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/LocationServiceSpec.scala
+++ b/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/LocationServiceSpec.scala
@@ -5,30 +5,15 @@
 
 package com.typesafe.conductr.bundlelib.scala
 
-import java.net.URI
-
 import com.typesafe.conductr.AkkaUnitTest
 import scala.concurrent.Await
-import scala.concurrent.duration.FiniteDuration
 
 class LocationServiceSpec extends AkkaUnitTest("StatusServiceSpec", "akka.loglevel = INFO") {
 
   "The LocationService functionality in the library" should {
     "return None when running in development mode" in {
       import system.dispatcher
-      Await.result(LocationService.lookup("/whatever"), timeout.duration) should be(None)
-    }
-
-    "return a default URI when running in development mode" in {
-      val default = new URI("http://127.0.0.1:9000")
-      LocationService.getUriOrExit(default)(None) should be(default)
-    }
-
-    "return the looked up URI when running in development mode" in {
-      val default = new URI("tcp://127.0.0.1:61616")
-      val lookedUpUri = new URI("tcp://127.0.0.1:10000")
-      val lookedUp: Option[(URI, Option[FiniteDuration])] = Some(lookedUpUri -> None)
-      LocationService.getUriOrExit(default)(lookedUp) should be(lookedUpUri)
+      Await.result(LocationService.lookup("/whatever"), timeout.duration) shouldBe None
     }
   }
 }

--- a/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/LocationServiceSpecWithEnv.scala
+++ b/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/LocationServiceSpecWithEnv.scala
@@ -12,7 +12,6 @@ import akka.http.server.Directives._
 import akka.stream.FlowMaterializer
 import akka.testkit.TestProbe
 import com.typesafe.conductr.AkkaUnitTest
-import com.typesafe.conductr.bundlelib.Env
 import java.net.{ URI, URL, InetSocketAddress }
 import scala.concurrent.Await
 import scala.util.{ Failure, Success }
@@ -25,7 +24,7 @@ class LocationServiceSpecWithEnv extends AkkaUnitTest("LocationServiceSpecWithEn
       val serviceUri = "http://service_interface:4711/known"
       withServerWithKnownService(serviceUri) {
         val service = LocationService.lookup("/known")
-        Await.result(service, timeout.duration) should be(Some(new URI(serviceUri) -> None))
+        Await.result(service, timeout.duration) shouldBe Some(new URI(serviceUri) -> None)
       }
     }
 
@@ -34,7 +33,7 @@ class LocationServiceSpecWithEnv extends AkkaUnitTest("LocationServiceSpecWithEn
       val serviceUrl = "http://service_interface:4711/known"
       withServerWithKnownService(serviceUrl) {
         val service = LocationService.lookup("/unknown")
-        Await.result(service, timeout.duration) should be(None)
+        Await.result(service, timeout.duration) shouldBe None
       }
     }
   }
@@ -45,7 +44,7 @@ class LocationServiceSpecWithEnv extends AkkaUnitTest("LocationServiceSpecWithEn
 
     val probe = new TestProbe(system)
 
-    val url = new URL(Env.SERVICE_LOCATOR)
+    val url = new URL(Env.serviceLocator.get)
     val server = Http(system).bind(url.getHost, url.getPort, settings = None)
     val mm = server.startHandlingWith(
       path("services" / Rest) { serviceName =>
@@ -64,8 +63,8 @@ class LocationServiceSpecWithEnv extends AkkaUnitTest("LocationServiceSpecWithEn
 
     try {
       server.localAddress(mm).onComplete {
-        case Success(address) => probe.ref ! address
-        case Failure(e)       => probe.ref ! e
+        case Success(localAddress) => probe.ref ! localAddress
+        case Failure(e)            => probe.ref ! e
       }
 
       val address = probe.expectMsgType[InetSocketAddress]

--- a/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/StatusServiceSpec.scala
+++ b/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/StatusServiceSpec.scala
@@ -13,7 +13,7 @@ class StatusServiceSpec extends AkkaUnitTest("StatusServiceSpec", "akka.loglevel
   "The StatusService functionality in the library" should {
     "return None when running in development mode" in {
       import system.dispatcher
-      Await.result(StatusService.signalStarted(), timeout.duration) should be(None)
+      Await.result(StatusService.signalStarted(), timeout.duration) shouldBe None
     }
   }
 }


### PR DESCRIPTION
The exit functions have been removed as it is best for the caller to implement such handling. A universal means of determining whether ConductR is running is provided in Env, which facilitates the caller being able to perform such handling.
