### PR TITLE
Easier declarations for ConnectionContext

### DIFF
--- a/akka-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/StatusServiceSpecWithEnv.scala
+++ b/akka-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/StatusServiceSpecWithEnv.scala
@@ -8,10 +8,10 @@ package com.typesafe.conductr.bundlelib.akka
 
 import java.net.{ InetSocketAddress, URL }
 
+import akka.actor.ActorRefFactory
 import akka.http.Http
 import akka.http.model.StatusCodes
 import akka.http.server.Directives._
-import akka.stream.ActorFlowMaterializer
 import akka.testkit.TestProbe
 import com.typesafe.conductr.bundlelib.scala.Env
 import com.typesafe.conductr.{ AkkaUnitTest, _ }
@@ -24,9 +24,9 @@ class StatusServiceSpecWithEnv extends AkkaUnitTest("StatusServiceSpecWithEnv", 
   "The StatusService functionality in the library" should {
     "be able to call the right URL to signal that it is up" in {
 
-      implicit val cc = ConnectionContext(system)
-
       val probe = new TestProbe(system)
+
+      implicit val cc = ConnectionContext()
 
       import system.dispatcher
       import cc.actorFlowMaterializer

--- a/scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/scala/ConnectionHandler.scala
+++ b/scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/scala/ConnectionHandler.scala
@@ -17,6 +17,15 @@ import scala.util.{ Failure, Success, Try }
 object ConnectionContext {
   def apply(executionContext: ExecutionContext): ConnectionContext =
     new ConnectionContext()(executionContext)
+
+  object Implicits {
+    /**
+     * An implicit global ConnectionContext.
+     * Import global when you want to provide the global ConnectionContext implicitly.
+     * This global ConnectionContext uses Scala's global execution context.
+     */
+    implicit val global = ConnectionContext(ExecutionContext.Implicits.global)
+  }
 }
 
 /**

--- a/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/LocationServiceSpec.scala
+++ b/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/LocationServiceSpec.scala
@@ -9,11 +9,12 @@ package com.typesafe.conductr.bundlelib.scala
 import com.typesafe.conductr.AkkaUnitTest
 import scala.concurrent.Await
 
-class LocationServiceSpec extends AkkaUnitTest("StatusServiceSpec", "akka.loglevel = INFO") {
+import com.typesafe.conductr.bundlelib.scala.ConnectionContext.Implicits.global
+
+class LocationServiceSpec extends AkkaUnitTest {
 
   "The LocationService functionality in the library" should {
     "return None when running in development mode" in {
-      implicit val cc = ConnectionContext(system.dispatcher)
       Await.result(LocationService.lookup("/whatever"), timeout.duration) shouldBe None
     }
 

--- a/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/LocationServiceSpecWithEnv.scala
+++ b/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/LocationServiceSpecWithEnv.scala
@@ -15,11 +15,14 @@ import akka.testkit.TestProbe
 import com.typesafe.conductr._
 import com.typesafe.conductr.AkkaUnitTest
 import java.net.{ URI, URL, InetSocketAddress }
+
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.{ Failure, Success }
 
 class LocationServiceSpecWithEnv extends AkkaUnitTest("LocationServiceSpecWithEnv", "akka.loglevel = INFO") {
+
+  import com.typesafe.conductr.bundlelib.scala.ConnectionContext.Implicits.global
 
   "The LocationService functionality in the library" should {
     "return the lookup url" in {
@@ -27,7 +30,6 @@ class LocationServiceSpecWithEnv extends AkkaUnitTest("LocationServiceSpecWithEn
     }
 
     "be able to look up a named service" in {
-      implicit val cc = ConnectionContext(system.dispatcher)
       val serviceUri = "http://service_interface:4711/known"
       withServerWithKnownService(serviceUri) {
         val service = LocationService.lookup("/known")
@@ -36,7 +38,6 @@ class LocationServiceSpecWithEnv extends AkkaUnitTest("LocationServiceSpecWithEn
     }
 
     "be able to look up a named service and return maxAge" in {
-      implicit val cc = ConnectionContext(system.dispatcher)
       val serviceUri = "http://service_interface:4711/known"
       withServerWithKnownService(serviceUri, Some(10)) {
         val service = LocationService.lookup("/known")
@@ -45,7 +46,6 @@ class LocationServiceSpecWithEnv extends AkkaUnitTest("LocationServiceSpecWithEn
     }
 
     "get back None for an unknown service" in {
-      implicit val cc = ConnectionContext(system.dispatcher)
       val serviceUrl = "http://service_interface:4711/known"
       withServerWithKnownService(serviceUrl) {
         val service = LocationService.lookup("/unknown")
@@ -54,7 +54,6 @@ class LocationServiceSpecWithEnv extends AkkaUnitTest("LocationServiceSpecWithEn
     }
 
     "Conveniently map to an Option[URI]" in {
-      implicit val cc = ConnectionContext(system.dispatcher)
       val serviceUri = "http://service_interface:4711/known"
       withServerWithKnownService(serviceUri, Some(10)) {
         val service = LocationService.lookup("/known").map(LocationService.toUri)(system.dispatcher)

--- a/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/StatusServiceSpec.scala
+++ b/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/StatusServiceSpec.scala
@@ -9,12 +9,12 @@ package com.typesafe.conductr.bundlelib.scala
 import com.typesafe.conductr.AkkaUnitTest
 import scala.concurrent.Await
 
+import com.typesafe.conductr.bundlelib.scala.ConnectionContext.Implicits.global
+
 class StatusServiceSpec extends AkkaUnitTest("StatusServiceSpec", "akka.loglevel = INFO") {
 
   "The StatusService functionality in the library" should {
     "return None when running in development mode" in {
-      implicit val cc = ConnectionContext(system.dispatcher)
-
       Await.result(StatusService.signalStartedOrExit(), timeout.duration) shouldBe None
       Await.result(StatusService.signalStarted(), timeout.duration) shouldBe None
     }

--- a/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/StatusServiceSpecWithEnv.scala
+++ b/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/StatusServiceSpecWithEnv.scala
@@ -17,13 +17,14 @@ import java.net.{ InetSocketAddress, URL }
 import scala.concurrent.Await
 import scala.util.{ Failure, Success }
 
+import com.typesafe.conductr.bundlelib.scala.ConnectionContext.Implicits.global
+
 class StatusServiceSpecWithEnv extends AkkaUnitTest("StatusServiceSpecWithEnv", "akka.loglevel = INFO") {
 
   "The StatusService functionality in the library" should {
     "be able to call the right URL to signal that it is up" in {
 
       import system.dispatcher
-      implicit val cc = ConnectionContext(system.dispatcher)
       implicit val materializer = ActorFlowMaterializer()
 
       val probe = new TestProbe(system)


### PR DESCRIPTION
The declarations for ConnectionContexts are now intended to be more idiomatic inline with their respective pure Scala and Akka apis.
