### PR TITLE
Introduces a cache for location lookups

### DIFF
--- a/akka-conductr-bundle-lib/src/test/java/com/typesafe/conductr/bundlelib/akka/LocationServiceTest.java
+++ b/akka-conductr-bundle-lib/src/test/java/com/typesafe/conductr/bundlelib/akka/LocationServiceTest.java
@@ -3,6 +3,7 @@ package com.typesafe.conductr.bundlelib.akka;
 import akka.actor.ActorSystem;
 import akka.japi.Option;
 import akka.util.Timeout;
+import com.typesafe.conductr.bundlelib.scala.LocationCache;
 import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
 import scala.concurrent.Await;
@@ -16,9 +17,10 @@ public class LocationServiceTest extends JUnitSuite {
         ActorSystem system = ActorSystem.create("MySystem");
 
         ConnectionContext cc = ConnectionContext.create(system);
+        LocationCache cache = new LocationCache();
         Timeout timeout = new Timeout(Duration.create(5, "seconds"));
         assertEquals(
-                Await.result(LocationService.getInstance().lookupWithContext("/whatever", cc), timeout.duration()),
+                Await.result(LocationService.getInstance().lookupWithContext("/whatever", cc, cache), timeout.duration()),
                 Option.none()
         );
     }

--- a/scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/scala/ConnectionHandler.scala
+++ b/scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/scala/ConnectionHandler.scala
@@ -47,7 +47,7 @@ private[bundlelib] class ConnectionHandler extends AbstractConnectionHandler {
    * of ConductR.
    */
   override def withConnectedRequest[T](
-    payload: Option[HttpPayload])(thunk: (Int, Map[String, Option[String]]) => Option[T])(implicit cc: CC): Future[Option[T]] = {
+    payload: Option[HttpPayload])(op: (Int, Map[String, Option[String]]) => Option[T])(implicit cc: CC): Future[Option[T]] = {
 
     import cc.executionContext
     payload.fold[Future[Option[T]]](Future.successful(None)) { p =>
@@ -61,7 +61,7 @@ private[bundlelib] class ConnectionHandler extends AbstractConnectionHandler {
               connection.connect()
               import scala.collection.JavaConverters._
               try {
-                thunk(
+                op(
                   connection.getResponseCode,
                   connection.getHeaderFields.asScala.foldLeft(Map.empty[String, Option[String]]) {
                     case (m, (k, v)) => m.updated(k, v.asScala.lastOption)

--- a/scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/scala/LocationCache.scala
+++ b/scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/scala/LocationCache.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2014-2015 Typesafe, Inc. All rights reserved.
+ * No information contained herein may be reproduced or transmitted in any form
+ * or by any means without the express written permission of Typesafe, Inc.
+ */
+
+package com.typesafe.conductr.bundlelib.scala
+
+import java.util.{ TimerTask, Timer }
+
+import scala.collection.concurrent.TrieMap
+import scala.concurrent.ExecutionContext.Implicits
+import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
+import scala.util.Success
+
+object LocationCache {
+  def apply() = new LocationCache
+}
+
+/**
+ * A cache specifically for locations in relation to service names. This is an expiring
+ * entry cache inspired by Spray Cache in its elements being captured as Futures, thus
+ * being able to cope with the thundering herds issue:
+ * http://ehcache.org/documentation/2.8/recipes/thunderingherd.
+ *
+ * Entries that provide a max age duration are scheduled to be removed at that time. The
+ * expectation is that this cache is used with such durations. Where there is no duration
+ * (this should be rare) then the cache entry is quickly removed after it has been determined.
+ * This removal also occurs when the entry cannot be established successfully.
+ */
+class LocationCache {
+
+  private val cache = TrieMap.empty[String, Future[Option[String]]]
+
+  val reaperTimer = new Timer()
+
+  def getOrElseUpdate(serviceName: String)(op: => Future[Option[(String, Option[FiniteDuration])]]): Future[Option[String]] = {
+    def dualOp: Future[Option[String]] = {
+      val locationAndMaxAge = op
+
+      import Implicits.global
+      locationAndMaxAge.andThen {
+        case Success(Some((_, Some(maxAge)))) =>
+          reaperTimer.schedule(new TimerTask {
+            override def run(): Unit = {
+              cache.remove(serviceName)
+            }
+          }, maxAge.toMillis)
+        case _ =>
+          cache.remove(serviceName)
+      }
+
+      locationAndMaxAge.map {
+        case Some((location, _)) => Some(location)
+        case None                => None
+      }
+    }
+    cache.getOrElseUpdate(serviceName, dualOp)
+  }
+}

--- a/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/LocationCacheSpec.scala
+++ b/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/LocationCacheSpec.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2014-2015 Typesafe, Inc. All rights reserved.
+ * No information contained herein may be reproduced or transmitted in any form
+ * or by any means without the express written permission of Typesafe, Inc.
+ */
+
+package com.typesafe.conductr.bundlelib.scala
+
+import com.typesafe.conductr.AkkaUnitTest
+
+import scala.concurrent.duration._
+import scala.concurrent.{ Await, Future }
+
+class LocationCacheSpec extends AkkaUnitTest {
+
+  "A location cache" should {
+    "invoke the op when there is no entry initially, return the cached entry when not, and expire" in {
+      var updates = 0
+      val cache = LocationCache()
+      def getFromCache(serviceName: String): Future[Option[String]] =
+        cache.getOrElseUpdate(serviceName) {
+          if (serviceName == "/someservice") {
+            updates += 1
+            Future.successful(Some("/somelocation" -> Some(100.millis)))
+          } else
+            throw new IllegalStateException(s"Some bad service: $serviceName")
+        }
+
+      val location1 = getFromCache("/someservice")
+      Await.result(location1, timeout.duration) shouldBe Some("/somelocation")
+      updates shouldBe 1
+
+      // Shouldn't invoke the op for this - it should just return the cache value
+      val location2 = getFromCache("/someservice")
+      Await.result(location2, timeout.duration) shouldBe Some("/somelocation")
+      updates shouldBe 1
+
+      // Let the cache expire
+      Thread.sleep(200)
+
+      val location3 = getFromCache("/someservice")
+      Await.result(location3, timeout.duration) shouldBe Some("/somelocation")
+      updates shouldBe 2
+    }
+  }
+}


### PR DESCRIPTION
The cache can be used across all implementations i.e. Scala, Akka, and potentially Play.

A structural type is used to convey a cache structure where it is required. There is a runtime cost associated with that of course, but it is at least type safe. I think that the small cost of a reflective call is worth the benefit of sharing a cache between implementations; in particular with Play.WS (I'm seeing if we can have the structural type conveyed for Play.WS also).
