### PR TITLE
Explicit WS Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,16 +237,16 @@ As with `conductr-bundle-lib` there are two services:
 * `com.typesafe.conductr.bundlelib.play.LocationService`
 * `com.typesafe.conductr.bundlelib.play.StatusService`
 
-Please read the section on `conductr-bundle-lib` and then `scala-conductr-bundle-lib` for an introduction to these services. Other than the `import`s for the types, the only difference in terms of API are usage is how a `ConnectionContext` is established. A `ConnectionContext` for Play requires an `ExecutionContext` and `Application` at a minimum. For convenience, we provide a default ConnectionContext using the default execution context and Play application. This may be imported e.g.:
+Please read the section on `conductr-bundle-lib` and then `scala-conductr-bundle-lib` for an introduction to these services. Other than the `import`s for the types, the only difference in terms of API are usage is how a `ConnectionContext` is established. A `ConnectionContext` for Play requires an `ExecutionContext` at a minimum. For convenience, we provide a default ConnectionContext using the default execution context. This may be imported e.g.:
 
 ```scala
   import com.typesafe.conductr.bundlelib.play.ConnectionContext.Implicits.defaultContext
 ```
 
-There is also a lower level method where the `ExecutionContext` and `Application` are passed in:
+There is also a lower level method where the `ExecutionContext` is passed in:
 
 ```scala
-implicit val cc = ConnectionContext(executionContext, application)
+implicit val cc = ConnectionContext(executionContext)
 ```
 
 ### Java
@@ -255,7 +255,7 @@ The following example illustrates how status is signalled using the Play Java AP
 
 ```java
 ConnectionContext cc =
-    ConnectionContext.create(HttpExecution.defaultContext(), Play.application());
+    ConnectionContext.create(HttpExecution.defaultContext());
 
   ...
 
@@ -266,7 +266,7 @@ Similarly here is a service lookup:
 
 ```java
 ConnectionContext cc =
-    ConnectionContext.create(HttpExecution.defaultContext(), Play.application());
+    ConnectionContext.create(HttpExecution.defaultContext());
 
   ...
 

--- a/play-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/ConnectionHandler.scala
+++ b/play-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/ConnectionHandler.scala
@@ -6,37 +6,49 @@
 
 package com.typesafe.conductr.bundlelib.play
 
+import com.ning.http.client.AsyncHttpClientConfig
 import com.typesafe.conductr.bundlelib.HttpPayload
 import com.typesafe.conductr.bundlelib.scala.{ AbstractConnectionHandler, AbstractConnectionContext }
-import play.{ Application => JavaApplication }
-import play.api.{ Application, Play }
-import play.api.libs.ws.WS
+import play.api.libs.ws.ning.{ NingWSClient, NingAsyncHttpClientConfigBuilder }
+import play.api.libs.ws.{ DefaultWSClientConfig, WSClient }
 import play.api.libs.concurrent.Execution.{ Implicits => PlayImplicits }
 
 import scala.concurrent.{ ExecutionContext, Future }
 
 object ConnectionContext {
-  def apply(executionContext: ExecutionContext, application: Application): ConnectionContext =
-    new ConnectionContext(application)(executionContext)
+  def apply(executionContext: ExecutionContext): ConnectionContext =
+    new ConnectionContext(Implicits.wsClient)(executionContext)
 
   /** JAVA API */
-  def create(executionContext: ExecutionContext, application: JavaApplication): ConnectionContext =
-    apply(executionContext, application.getWrappedApplication)
+  def create(executionContext: ExecutionContext): ConnectionContext =
+    apply(executionContext)
 
   object Implicits {
     /**
+     * A WS client for the purposes of communicating with ConductR.
+     */
+    implicit val wsClient = {
+      val ningClientConfig = new NingAsyncHttpClientConfigBuilder(new DefaultWSClientConfig()).build()
+      val clientConfig = new AsyncHttpClientConfig.Builder(ningClientConfig)
+        .setCompressionEnabled(true)
+        .build()
+      new NingWSClient(clientConfig)
+    }
+
+    /**
      * An implicit defaultContext ConnectionContext.
-     * Import global when you want to provide the global ConnectionContext implicitly.
+     * Import Implicits when you want to provide the global ConnectionContext implicitly.
      * This global ConnectionContext uses Play's default execution context.
      */
-    implicit val defaultContext = ConnectionContext(PlayImplicits.defaultContext, Play.current)
+    implicit val defaultContext = ConnectionContext(PlayImplicits.defaultContext)
   }
 }
 
 /**
  * When performing Play.WS connections, this is the connection context to use.
  */
-class ConnectionContext(val application: Application)(implicit val executionContext: ExecutionContext) extends AbstractConnectionContext
+class ConnectionContext(val wsClient: WSClient)(implicit val executionContext: ExecutionContext)
+  extends AbstractConnectionContext
 
 /**
  * INTERNAL API
@@ -53,7 +65,7 @@ private[bundlelib] class ConnectionHandler extends AbstractConnectionHandler {
       val url = p.getUrl
       val urlStr = url.toString
 
-      val request = WS.url(urlStr)(cc.application)
+      val request = cc.wsClient.url(urlStr)
         .withHeaders("User-Agent" -> UserAgent, "Host" -> url.getHost)
         .withMethod(p.getRequestMethod)
         .withFollowRedirects(follow = false)

--- a/play-conductr-bundle-lib/src/test/java/com/typesafe/conductr/bundlelib/play/LocationServiceTest.java
+++ b/play-conductr-bundle-lib/src/test/java/com/typesafe/conductr/bundlelib/play/LocationServiceTest.java
@@ -4,10 +4,8 @@ import akka.util.Timeout;
 import com.typesafe.conductr.bundlelib.scala.LocationCache;
 import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
-import play.Application;
 import play.libs.F;
 import play.libs.HttpExecution;
-import play.test.Helpers;
 import scala.concurrent.duration.Duration;
 
 import static org.junit.Assert.assertEquals;
@@ -15,10 +13,7 @@ import static org.junit.Assert.assertEquals;
 public class LocationServiceTest extends JUnitSuite {
     @Test
     public void return_None_when_running_in_development_mode() throws Exception {
-        ConnectionContext cc = ConnectionContext.create(
-            HttpExecution.defaultContext(),
-            new Application(Helpers.fakeApplication().getWrappedApplication())
-        );
+        ConnectionContext cc = ConnectionContext.create(HttpExecution.defaultContext());
         LocationCache cache = new LocationCache();
         Timeout timeout = new Timeout(Duration.create(5, "seconds"));
 

--- a/play-conductr-bundle-lib/src/test/java/com/typesafe/conductr/bundlelib/play/StatusServiceTest.java
+++ b/play-conductr-bundle-lib/src/test/java/com/typesafe/conductr/bundlelib/play/StatusServiceTest.java
@@ -14,10 +14,7 @@ import static org.junit.Assert.assertEquals;
 public class StatusServiceTest extends JUnitSuite {
     @Test
     public void return_None_when_running_in_development_mode() throws Exception {
-        ConnectionContext cc = ConnectionContext.create(
-            HttpExecution.defaultContext(),
-            new Application(Helpers.fakeApplication().getWrappedApplication())
-        );
+        ConnectionContext cc = ConnectionContext.create(HttpExecution.defaultContext());
         Timeout timeout = new Timeout(Duration.create(5, "seconds"));
 
         assertEquals(

--- a/play-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/LocationServiceSpecWithEnv.scala
+++ b/play-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/LocationServiceSpecWithEnv.scala
@@ -18,15 +18,11 @@ import akka.testkit.TestProbe
 import com.typesafe.conductr.bundlelib.play.ConnectionContext.Implicits
 import com.typesafe.conductr.bundlelib.scala.{ LocationCache, Env }
 import com.typesafe.conductr.{ AkkaUnitTest, _ }
-import play.api.Play
-import play.api.test.FakeApplication
 
 import scala.concurrent.Await
 import scala.util.{ Failure, Success }
 
 class LocationServiceSpecWithEnv extends AkkaUnitTest("LocationServiceSpecWithEnv", "akka.loglevel = INFO") {
-
-  Play.start(FakeApplication())
 
   import Implicits.defaultContext
 

--- a/play-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/StatusServiceSpecWithEnv.scala
+++ b/play-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/StatusServiceSpecWithEnv.scala
@@ -16,15 +16,11 @@ import akka.testkit.TestProbe
 import com.typesafe.conductr.bundlelib.play.ConnectionContext.Implicits
 import com.typesafe.conductr.bundlelib.scala.Env
 import com.typesafe.conductr.{ AkkaUnitTest, _ }
-import play.api.Play
-import play.api.test.FakeApplication
 
 import scala.concurrent.Await
 import scala.util.{ Failure, Success }
 
 class StatusServiceSpecWithEnv extends AkkaUnitTest("StatusServiceSpecWithEnv", "akka.loglevel = INFO") {
-
-  Play.start(FakeApplication())
 
   "The StatusService functionality in the library" should {
     "be able to call the right URL to signal that it is up" in {


### PR DESCRIPTION
For further flexibility, and compatibility with Play 2.4, WSClient is now passed around rather than Application. In addition, this permits modules containing bundle lib calls to be used prior to an application being formed.

Application dependencies are now entirely removed.
