### PR TITLE
Use name_PROTOCOL instead of name_HOST_PROTOCOL (closes #35)

### DIFF
--- a/akka-conductr-bundle-lib/build.sbt
+++ b/akka-conductr-bundle-lib/build.sbt
@@ -10,8 +10,8 @@ name := "akka-conductr-bundle-lib"
 libraryDependencies ++= List(
   Library.akkaCluster,
   Library.akkaHttp,
-  Library.akkaTestkit     % "test",
-  Library.scalaTest       % "test"
+  Library.akkaTestkit % "test",
+  Library.scalaTest   % "test"
 )
 
 fork in Test := true
@@ -24,7 +24,7 @@ def groupByFirst(tests: Seq[TestDefinition]) =
         new Group("WithEnvForHost", t, SubProcess(ForkOptions(envVars = Map(
           "BUNDLE_HOST_IP" -> "10.0.1.10",
           "BUNDLE_SYSTEM" -> "some-system",
-          "AKKA_REMOTE_HOST_PROTOCOL" -> "tcp",
+          "AKKA_REMOTE_PROTOCOL" -> "tcp",
           "AKKA_REMOTE_HOST_PORT" -> "10000",
           "AKKA_REMOTE_OTHER_PROTOCOLS" -> "",
           "AKKA_REMOTE_OTHER_IPS" -> "",
@@ -33,7 +33,7 @@ def groupByFirst(tests: Seq[TestDefinition]) =
         new Group("WithEnvForOneOther", t, SubProcess(ForkOptions(envVars = Map(
           "BUNDLE_HOST_IP" -> "10.0.1.10",
           "BUNDLE_SYSTEM" -> "some-system",
-          "AKKA_REMOTE_HOST_PROTOCOL" -> "tcp",
+          "AKKA_REMOTE_PROTOCOL" -> "tcp",
           "AKKA_REMOTE_HOST_PORT" -> "10000",
           "AKKA_REMOTE_OTHER_PROTOCOLS" -> "udp",
           "AKKA_REMOTE_OTHER_IPS" -> "10.0.1.11",
@@ -42,7 +42,7 @@ def groupByFirst(tests: Seq[TestDefinition]) =
         new Group("WithEnvForOthers", t, SubProcess(ForkOptions(envVars = Map(
           "BUNDLE_HOST_IP" -> "10.0.1.10",
           "BUNDLE_SYSTEM" -> "some-system",
-          "AKKA_REMOTE_HOST_PROTOCOL" -> "tcp",
+          "AKKA_REMOTE_PROTOCOL" -> "tcp",
           "AKKA_REMOTE_HOST_PORT" -> "10000",
           "AKKA_REMOTE_OTHER_PROTOCOLS" -> "udp:tcp",
           "AKKA_REMOTE_OTHER_IPS" -> "10.0.1.11:10.0.1.12",

--- a/akka-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/akka/ClusterProperties.scala
+++ b/akka-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/akka/ClusterProperties.scala
@@ -35,7 +35,7 @@ object ClusterProperties {
     val akkaSeeds = (for {
       bundleHostIp <- sys.env.get("BUNDLE_HOST_IP")
       bundleSystem <- sys.env.get("BUNDLE_SYSTEM")
-      akkaRemoteHostProtocol <- sys.env.get(s"${akkaRemoteEndpointName}_HOST_PROTOCOL")
+      akkaRemoteHostProtocol <- sys.env.get(s"${akkaRemoteEndpointName}_PROTOCOL")
       akkaRemoteHostPort <- sys.env.get(s"${akkaRemoteEndpointName}_HOST_PORT")
       akkaRemoteOtherProtocolsConcat <- sys.env.get(s"${akkaRemoteEndpointName}_OTHER_PROTOCOLS")
       akkaRemoteOtherIpsConcat <- sys.env.get(s"${akkaRemoteEndpointName}_OTHER_IPS")


### PR DESCRIPTION
This is related to https://github.com/typesafehub/typesafe-conductr/pull/560 and has to be merged in sync.
