### PR TITLE
Set Play's actor system name to a bundle's

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,8 @@ In order for an application or service to take advantage of this guarantee provi
 import com.typesafe.conductr.bundlelib.akka.Env
 
 val config = Env.asConfig
-val app1 = ActorSystem("MyApp1", config.withFallback(ConfigFactory.load()))
+val systemName = sys.env.getOrElse("BUNDLE_SYSTEM", "MyApp1")
+val app1 = ActorSystem(systemName, config.withFallback(ConfigFactory.load()))
 ```
 
 Clusters will then be formed correctly. The above call looks for an endpoint named `akka-remote` by default. Therefore if you must declare the Akka remoting port as seed. The following endpoint declaration within a `build.sbt` shows how:

--- a/play-conductr-bundle-lib/build.sbt
+++ b/play-conductr-bundle-lib/build.sbt
@@ -25,6 +25,7 @@ def groupByFirst(tests: Seq[TestDefinition]) =
       case ("WithEnv", t) =>
         new Group("WithEnv", t, SubProcess(ForkOptions(envVars = Map(
           "BUNDLE_ID" -> "0BADF00DDEADBEEF",
+          "BUNDLE_SYSTEM" -> "somesys",
           "CONDUCTR_STATUS" -> "http://127.0.0.1:40007",
           "SERVICE_LOCATOR" -> "http://127.0.0.1:40008/services",
           "WEB_BIND_IP" -> "127.0.0.1",

--- a/play-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/Env.scala
+++ b/play-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/Env.scala
@@ -23,6 +23,8 @@ object Env extends com.typesafe.conductr.bundlelib.scala.Env {
     val httpAddress = sys.env.get(s"${webName}_BIND_IP").toList.map("http.address" -> _)
     val httpPort = sys.env.get(s"${webName}_BIND_PORT").toList.map("http.port" -> _)
 
-    ConfigFactory.parseMap((httpAddress ++ httpPort).toMap.asJava)
+    val playActorSystem = sys.env.get("BUNDLE_SYSTEM").toList.map("play.akka.actor-system" -> _)
+
+    ConfigFactory.parseMap((httpAddress ++ httpPort ++ playActorSystem).toMap.asJava)
   }
 }

--- a/play-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/EnvSpecWithEnv.scala
+++ b/play-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/EnvSpecWithEnv.scala
@@ -16,6 +16,7 @@ class EnvSpecWithEnv extends AkkaUnitTest("EnvSpecWithEnvForHost", "akka.logleve
     "initialize the env like expected" in {
       config.getString("http.address") shouldBe "127.0.0.1"
       config.getString("http.port") shouldBe "9000"
+      config.getString("play.akka.actor-system") shouldBe "somesys"
     }
   }
 }


### PR DESCRIPTION
Saves on configuration for the user.

Also, the README is enhanced w.r.t. to Akka so that the BUNDLE_SYSTEM env's usage is encouraged for the same purposes.
