### PR TITLE
Improved test reliability

### DIFF
--- a/play24-conductr-bundle-lib/build.sbt
+++ b/play24-conductr-bundle-lib/build.sbt
@@ -26,8 +26,8 @@ def groupByFirst(tests: Seq[TestDefinition]) =
         new Group("WithEnv", t, SubProcess(ForkOptions(envVars = Map(
           "BUNDLE_ID" -> "0BADF00DDEADBEEF",
           "BUNDLE_SYSTEM" -> "somesys",
-          "CONDUCTR_STATUS" -> "http://127.0.0.1:40007",
-          "SERVICE_LOCATOR" -> "http://127.0.0.1:40008/services",
+          "CONDUCTR_STATUS" -> "http://127.0.0.1:30007",
+          "SERVICE_LOCATOR" -> "http://127.0.0.1:30008/services",
           "WEB_BIND_IP" -> "127.0.0.1",
           "WEB_BIND_PORT" -> "9000"
         ))))


### PR DESCRIPTION
When introducing the play24 module I had forgot to assign distinct ports to its tests. This could cause tests to fail when performed in parallel.
