### PR TITLE
Removal of the incorrect host header

### DIFF
--- a/akka23-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/akka/ConnectionHandler.scala
+++ b/akka23-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/akka/ConnectionHandler.scala
@@ -90,7 +90,6 @@ private[bundlelib] class ConnectionHandler extends AbstractConnectionHandler {
 
       val request = requestMethod
         .addHeader(`User-Agent`(UserAgent))
-        .addHeader(Host(url.getHost))
 
       val requestSource = Source.single(request)
         .via(connection)


### PR DESCRIPTION
This should not have been present in the first place, and now with an Akka http 2.0.1 server will fail given the missing port. We now let akka-http add the header.