### PR TITLE
WIP - DON'T MERGE: Akka 2.4 + Play 2.5 Bundle Lib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ script:
 - jdk_switcher use oraclejdk7
 - sbt conductRBundleLib/test:test scalaConductRBundleLib/test:test akka23ConductRBundleLib/test:test play23ConductRBundleLib/test:test scalaConductRClientLib/test:test akka23ConductRClientLib/test:test play23ConductRClientLib/test:test
 - jdk_switcher use oraclejdk8
-- sbt conductRBundleLib/test:test scalaConductRBundleLib/test:test akka23ConductRBundleLib/test:test play23ConductRBundleLib/test:test scalaConductRClientLib/test:test akka23ConductRClientLib/test:test play23ConductRClientLib/test:test javaConductRBundleLib/test:test
+- sbt conductRBundleLib/test:test scalaConductRBundleLib/test:test akka23ConductRBundleLib/test:test akka24ConductRBundleLib/test:test play23ConductRBundleLib/test:test play24ConductRBundleLib/test:test play25ConductRBundleLib/test:test scalaConductRClientLib/test:test akka23ConductRClientLib/test:test akka24ConductRClientLib/test:test play23ConductRClientLib/test:test play24ConductRClientLib/test:test play25ConductRClientLib/test:test javaConductRBundleLib/test:test

--- a/README.md
+++ b/README.md
@@ -20,8 +20,10 @@ For ConductR 1.1 and above, the libraries use Akka streams/http 2.0 and will be:
 * `"com.typesafe.conductr" %% "java-conductr-bundle-lib"   % "1.2.0"`
 * `"com.typesafe.conductr" %% "scala-conductr-bundle-lib"  % "1.2.0"`
 * `"com.typesafe.conductr" %% "akka23-conductr-bundle-lib" % "1.2.0"`
+* `"com.typesafe.conductr" %% "akka24-conductr-bundle-lib" % "1.2.0"`
 * `"com.typesafe.conductr" %% "play23-conductr-bundle-lib" % "1.2.0"`
 * `"com.typesafe.conductr" %% "play24-conductr-bundle-lib" % "1.2.0"`
+* `"com.typesafe.conductr" %% "play25-conductr-bundle-lib" % "1.2.0"`
 
 Note that the above libraries require the following resolver when using sbt:
 
@@ -155,7 +157,7 @@ In general, the return value of `signalStartedOrExit` is not used and your progr
 
 In case you are interested, the function returns a `Future[Option[Unit]]` where a future `Some(())` indicates that ConductR has successfully acknowledged the startup signal. A future of `None` indicates that the bundle has not been started by ConductR.
 
-## akka23-conductr-bundle-lib
+## akka[23|24]-conductr-bundle-lib
 
 This library provides a reactive API using [Akka Http](http://akka.io/docs/) and should be used when you are using Akka. The library depends on `scala-conductr-bundle-lib` and can be used for both Java and Scala.
 
@@ -257,7 +259,7 @@ BundleKeys.endpoints := Map("akka-remote" -> Endpoint("tcp"))
 
 In the above, no declaration of `services` is required as akka remoting is an internal, cluster-wide TCP service.
 
-## play[23|24]-conductr-bundle-lib
+## play[23|24|25]-conductr-bundle-lib
 
 Please select the Play 2.3 or 2.4 variant depending on whether you are using Play 2.3 or Play 2.4 respectively.
 
@@ -324,7 +326,7 @@ object Global extends GlobalSettings {
 }
 ```
 
-#### Play 2.4
+#### Play 2.4 / 2.5
 
 Your `application.conf` should contain the following:
 

--- a/akka24-common/build.sbt
+++ b/akka24-common/build.sbt
@@ -1,0 +1,5 @@
+name := "akka24-conductr-lib-common"
+
+libraryDependencies ++= List(
+  Library.akka24Http
+)

--- a/akka24-common/src/main/scala/com/typesafe/conductr/lib/akka/ConnectionHandler.scala
+++ b/akka24-common/src/main/scala/com/typesafe/conductr/lib/akka/ConnectionHandler.scala
@@ -1,0 +1,153 @@
+package com.typesafe.conductr.lib.akka
+
+import akka.actor._
+import akka.http.scaladsl.Http.OutgoingConnection
+import akka.http.scaladsl.client.RequestBuilding._
+import akka.http.scaladsl.marshalling.Marshal
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.unmarshalling.Unmarshal
+import akka.http.scaladsl.{ Http, HttpExt }
+import akka.http.scaladsl.model.headers.{ Host, `User-Agent` }
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{ Flow, Sink, Source }
+import com.typesafe.conductr.lib.HttpPayload
+import com.typesafe.conductr.lib.scala.{ AbstractConnectionContext, AbstractConnectionHandler }
+
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.util.Try
+
+object ConnectionContext {
+  def apply()(implicit context: ActorRefFactory): ConnectionContext = {
+    val system = actorSystemOf(context)
+    apply(Http(system), ActorMaterializer.create(system))
+  }
+
+  def apply(httpExt: HttpExt, actorMaterializer: ActorMaterializer)(implicit context: ActorRefFactory): ConnectionContext =
+    new ConnectionContext(httpExt, actorMaterializer, context)
+
+  /** JAVA API */
+  def create(context: ActorRefFactory): ConnectionContext =
+    apply()(context)
+
+  /** JAVA API */
+  def create(httpExt: HttpExt, actorMaterializer: ActorMaterializer, context: ActorRefFactory): ConnectionContext =
+    apply(httpExt, actorMaterializer)(context)
+
+  private def actorSystemOf(context: ActorRefFactory): ActorSystem = {
+    val system = context match {
+      case s: ExtendedActorSystem => s
+      case c: ActorContext        => c.system
+      case null                   => throw new IllegalArgumentException("ActorRefFactory context must be defined")
+      case _ =>
+        throw new IllegalArgumentException(s"ActorRefFactory context must be a ActorSystem or ActorContext, got [${context.getClass.getName}]")
+    }
+    system
+  }
+}
+
+class ConnectionContext(
+  val httpExt: HttpExt,
+  implicit val actorMaterializer: ActorMaterializer,
+  implicit val context: ActorRefFactory) extends AbstractConnectionContext
+
+/**
+ * Mix this trait into your Actor if you need an implicit
+ * ConnectionContext in scope.
+ *
+ * Subclass may override `httpExt` and `actorMaterializer` to define custom
+ * values for the `ConnectionContext`.
+ */
+trait ImplicitConnectionContext { this: Actor =>
+
+  def httpExt: HttpExt =
+    Http(context.system)
+
+  def actorMaterializer: ActorMaterializer =
+    ActorMaterializer.create(context)
+
+  final implicit val cc: ConnectionContext = ConnectionContext(httpExt, actorMaterializer)
+}
+
+/**
+ * INTERNAL API
+ * Handles the Akka-http requests and responses
+ */
+class ConnectionHandler extends AbstractConnectionHandler {
+
+  override protected type CC = ConnectionContext
+
+  override def withConnectedRequest[T](payload: Option[HttpPayload])(handler: (Int, Map[String, Option[String]]) => Option[T])(implicit cc: CC): Future[Option[T]] = {
+    payload.fold[Future[Option[T]]](Future.successful(None)) { p =>
+      val connection = createConnection(p)
+      val request = createRequest(p)
+
+      Source.fromFuture(request)
+        .via(connection)
+        .map { response =>
+          handler(
+            response.status.intValue(),
+            response.headers.foldLeft(Map.empty[String, Option[String]]) {
+              case (m, header) => m.updated(header.name(), Some(header.value()))
+            })
+        }
+        .runWith(Sink.head)(cc.actorMaterializer)
+    }
+  }
+
+  // TODO: Refactor this so that the body is part of `HttpPayload`. As a body type use [[org.reactivestreams.Publisher<T>]].
+  def withConnectedRequest[T](payload: HttpPayload, body: Option[Future[RequestEntity]] = None)(handler: (Int, Map[String, Option[String]], ResponseEntity) => Future[T])(implicit cc: CC): Future[T] = {
+    val connection = createConnection(payload)
+    val request = createRequest(payload, body)
+
+    Source.fromFuture(request)
+      .via(connection)
+      .mapAsync(1) { response =>
+        handler(
+          response.status.intValue(),
+          response.headers.foldLeft(Map.empty[String, Option[String]]) {
+            case (m, header) => m.updated(header.name(), Some(header.value()))
+          },
+          response.entity)
+      }
+      .runWith(Sink.head)(cc.actorMaterializer)
+  }
+
+  //  def withConnectedStream[T](payload: HttpPayload)(handler: HttpResponse => Future[Source[T, Unit]])(implicit cc: CC): Future[Source[T, Unit]] = {
+  //    import cc.actorMaterializer
+  //    import cc.actorMaterializer.executionContext
+  //
+  //    val connection = createConnection(payload)
+  //    val request = createRequest(payload, None)
+  //
+  //    Source.fromFuture(request)
+  //      .via(connection)
+  //      .mapAsync(1)(unmarshalling)
+  //      .runWith(Sink.head)(cc.actorMaterializer)
+  //  }
+
+  private def createConnection(payload: HttpPayload)(implicit cc: CC) =
+    cc.httpExt.outgoingConnection(payload.getUrl.getHost, payload.getUrl.getPort)
+
+  private def createRequest(payload: HttpPayload, body: Option[Future[RequestEntity]] = None)(implicit cc: CC): Future[HttpRequest] = {
+    val url = payload.getUrl
+
+    val requestBuilder = payload.getRequestMethod match {
+      case "GET"     => Get
+      case "POST"    => Post
+      case "PUT"     => Put
+      case "PATCH"   => Patch
+      case "DELETE"  => Delete
+      case "OPTIONS" => Options
+      case "HEAD"    => Head
+    }
+
+    import cc.actorMaterializer.executionContext
+    val requestF = body
+      .fold(Future.successful(requestBuilder(url.toString))) { _.map(b => requestBuilder(url.toString, b)) }
+
+    requestF.map { request =>
+      request.addHeader(`User-Agent`(UserAgent))
+      request.addHeader(Host(url.getHost, url.getPort))
+    }
+  }
+}

--- a/akka24-conductr-bundle-lib/build.sbt
+++ b/akka24-conductr-bundle-lib/build.sbt
@@ -1,18 +1,11 @@
 import Tests._
 
-name := "akka23-conductr-client-lib"
+name := "akka24-conductr-bundle-lib"
 
 libraryDependencies ++= List(
-  Library.akkaSse23,
-  Library.akkaContribExtra,
-  Library.play23Json,
-  Library.akka23HttpTestkit % "test",
-  Library.akka23Testkit     % "test",
-  Library.scalaTest         % "test"
-)
-
-resolvers ++= List(
-  Resolvers.typesafeBintrayReleases
+  Library.akka24Cluster,
+  Library.akka24Testkit % "test",
+  Library.scalaTest     % "test"
 )
 
 fork in Test := true

--- a/akka24-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/akka/Env.scala
+++ b/akka24-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/akka/Env.scala
@@ -1,0 +1,69 @@
+package com.typesafe.conductr.bundlelib.akka
+
+import com.typesafe.config.{ ConfigFactory, Config }
+import scala.collection.JavaConverters._
+
+/**
+ * Provides functions to set up the Akka cluster environment in accordance with what ConductR provides.
+ */
+object Env extends com.typesafe.conductr.bundlelib.scala.Env {
+
+  private final val MultiValDelim = ':'
+
+  /**
+   * Provides various Akka related properties, e.g. Akka seed nodes, given the environment that ConductR's provides.
+   * If ConductR did not start this program there is no effect.
+   *
+   * If ConductR did start this then the seed node properties for an Akka cluster are automatically overridden.
+   * In this case, if the AKKA_REMOTE_OTHER_IPS env is non empty then this node will join the cluster indicated by that
+   * env's colon delimited seed node ips (and also AKKA_REMOTE_OTHER_PROTOCOLS and AKKA_REMOTE_OTHER_PORTS envs).
+   * Note that the service name of AKKA_REMOTE is used by convention for Akka clustering, but this itself can be
+   * overridden by supplying a AKKA_REMOTE_ENDPOINT_NAME env.
+   *
+   * Also in the case where ConductR did start this bundle but there is no AKKA_REMOTE_OTHER_IPS value then the current
+   * node is assumed to be starting the cluster.
+   */
+  def asConfig: Config = {
+    val akkaRemoteEndpointName = sys.env.getOrElse("AKKA_REMOTE_ENDPOINT_NAME", "AKKA_REMOTE")
+
+    def presentSeedNode(protocol: String, bundleSystem: String, bundleSystemVersion: String, ip: String, port: String, n: Int): (String, String) =
+      s"akka.cluster.seed-nodes.$n" -> s"akka.$protocol://${bundleSystem}-${bundleSystemVersion}@$ip:$port"
+
+    val akkaSeeds = {
+      val akkaSeeds =
+        for {
+          bundleHostIp <- sys.env.get("BUNDLE_HOST_IP").toList
+          bundleSystem <- sys.env.get("BUNDLE_SYSTEM")
+          bundleSystemVersion <- sys.env.get("BUNDLE_SYSTEM_VERSION")
+          akkaRemoteProtocol <- sys.env.get(s"${akkaRemoteEndpointName}_PROTOCOL")
+          akkaRemoteHostPort <- sys.env.get(s"${akkaRemoteEndpointName}_HOST_PORT")
+          akkaRemoteOtherProtocolsConcat <- sys.env.get(s"${akkaRemoteEndpointName}_OTHER_PROTOCOLS")
+          akkaRemoteOtherIpsConcat <- sys.env.get(s"${akkaRemoteEndpointName}_OTHER_IPS")
+          akkaRemoteOtherPortsConcat <- sys.env.get(s"${akkaRemoteEndpointName}_OTHER_PORTS")
+        } yield if (akkaRemoteOtherProtocolsConcat.nonEmpty) {
+          val akkaRemoteOtherProtocols = akkaRemoteOtherProtocolsConcat.split(MultiValDelim)
+          val akkaRemoteOtherIps = akkaRemoteOtherIpsConcat.split(MultiValDelim)
+          val akkaRemoteOtherPorts = akkaRemoteOtherPortsConcat.split(MultiValDelim)
+          val otherAkkaRemoteNodes = for {
+            (((protocol, ip), port), n) <- akkaRemoteOtherProtocols.zip(akkaRemoteOtherIps).zip(akkaRemoteOtherPorts).zipWithIndex
+          } yield presentSeedNode(protocol, mkSystemId(bundleSystem), mkSystemId(bundleSystemVersion), ip, port, n)
+          otherAkkaRemoteNodes.toList
+        } else
+          List(presentSeedNode(akkaRemoteProtocol, mkSystemId(bundleSystem), mkSystemId(bundleSystemVersion), bundleHostIp, akkaRemoteHostPort, 0))
+      akkaSeeds.flatten
+    }
+    val hostname = sys.env.get("BUNDLE_HOST_IP").toList.map("akka.remote.netty.tcp.hostname" -> _)
+    val port = sys.env.get(s"${akkaRemoteEndpointName}_HOST_PORT").toList.map("akka.remote.netty.tcp.port" -> _)
+
+    ConfigFactory.parseMap((akkaSeeds ++ hostname ++ port).toMap.asJava)
+  }
+
+  /**
+   * take a string representing a system name and form a valid actor system name from it.
+   */
+  def mkSystemId(system: String): String =
+    system.dropWhile(!_.isLetterOrDigit).collect {
+      case c if c.isLetterOrDigit || c == '-' || c == '_' => c
+      case c if c == '.'                                  => '_'
+    }
+}

--- a/akka24-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/akka/LocationService.scala
+++ b/akka24-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/akka/LocationService.scala
@@ -1,0 +1,39 @@
+package com.typesafe.conductr.bundlelib.akka
+
+import java.net.URI
+
+import com.typesafe.conductr.lib.akka._
+import com.typesafe.conductr.bundlelib.scala.{ CacheLike, AbstractLocationService }
+
+import akka.japi.{ Option => JOption }
+
+import scala.concurrent.ExecutionContext.Implicits
+import scala.concurrent.Future
+import scala.language.reflectiveCalls
+
+object LocationService extends LocationService(new ConnectionHandler) {
+  /** JAVA API */
+  def getInstance: LocationService =
+    LocationService
+}
+
+/**
+ * LocationService used to look up services using the Typesafe ConductR Service Locator.
+ */
+class LocationService(handler: ConnectionHandler) extends AbstractLocationService(handler) {
+  override protected type CC = ConnectionContext
+
+  override def lookup(serviceName: String, fallback: URI, cache: CacheLike)(implicit cc: CC): Future[Option[URI]] =
+    if (Env.isRunByConductR)
+      cache.getOrElseUpdate(serviceName) {
+        handler.withConnectedRequest(createLookupPayload(serviceName))(handleLookup)
+      }
+    else
+      Future.successful(Some(fallback))
+
+  /** JAVA API */
+  def lookupWithContext(serviceName: String, fallback: URI, cache: CacheLike, cc: CC): Future[JOption[URI]] = {
+    import Implicits.global
+    lookup(serviceName, fallback, cache)(cc).map(JOption.fromScalaOption)
+  }
+}

--- a/akka24-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/akka/StatusService.scala
+++ b/akka24-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/akka/StatusService.scala
@@ -1,0 +1,43 @@
+package com.typesafe.conductr.bundlelib.akka
+
+import com.typesafe.conductr.lib.akka._
+import com.typesafe.conductr.bundlelib.scala.AbstractStatusService
+
+import akka.japi.{ Option => JOption }
+
+import scala.concurrent.ExecutionContext.Implicits
+import scala.concurrent.Future
+
+object StatusService extends StatusService(new ConnectionHandler) {
+  /** JAVA API */
+  def getInstance: StatusService =
+    StatusService
+}
+
+/**
+ * StatusService used to communicate the bundle status to the Typesafe ConductR Status Server.
+ */
+class StatusService(handler: ConnectionHandler) extends AbstractStatusService(handler) {
+
+  override protected type CC = ConnectionContext
+
+  override def signalStartedOrExit()(implicit cc: CC): Future[Option[Unit]] = {
+    import Implicits.global
+    signalStarted().recover(handleSignalOrExit)
+  }
+
+  override def signalStarted()(implicit cc: CC): Future[Option[Unit]] =
+    handler.withConnectedRequest(createSignalStartedPayload)(handleSignal)
+
+  /** JAVA API */
+  def signalStartedOrExitWithContext(cc: CC): Future[JOption[Unit]] = {
+    import Implicits.global
+    signalStartedOrExit()(cc).map(JOption.fromScalaOption)
+  }
+
+  /** JAVA API */
+  def signalStartedWithContext(cc: CC): Future[JOption[Unit]] = {
+    import Implicits.global
+    signalStarted()(cc).map(JOption.fromScalaOption)
+  }
+}

--- a/akka24-conductr-bundle-lib/src/test/java/com/typesafe/conductr/bundlelib/akka/LocationServiceTest.java
+++ b/akka24-conductr-bundle-lib/src/test/java/com/typesafe/conductr/bundlelib/akka/LocationServiceTest.java
@@ -1,0 +1,31 @@
+package com.typesafe.conductr.bundlelib.akka;
+
+import akka.actor.ActorSystem;
+import akka.japi.Option;
+import akka.util.Timeout;
+import com.typesafe.conductr.bundlelib.scala.LocationCache;
+import org.junit.Test;
+import org.scalatest.junit.JUnitSuite;
+import scala.concurrent.Await;
+import scala.concurrent.duration.Duration;
+import com.typesafe.conductr.lib.akka.ConnectionContext;
+
+import java.net.URI;
+
+import static org.junit.Assert.assertEquals;
+
+public class LocationServiceTest extends JUnitSuite {
+    @Test
+    public void return_the_fallback_when_running_in_development_mode() throws Exception {
+        ActorSystem system = ActorSystem.create("MySystem");
+
+        URI fallback = new URI("/fallback");
+        LocationCache cache = new LocationCache();
+        ConnectionContext cc = ConnectionContext.create(system);
+        Timeout timeout = new Timeout(Duration.create(5, "seconds"));
+        assertEquals(
+            Await.result(LocationService.getInstance().lookupWithContext("/whatever", fallback, cache, cc), timeout.duration()),
+            Option.some(fallback)
+        );
+    }
+}

--- a/akka24-conductr-bundle-lib/src/test/java/com/typesafe/conductr/bundlelib/akka/StatusServiceTest.java
+++ b/akka24-conductr-bundle-lib/src/test/java/com/typesafe/conductr/bundlelib/akka/StatusServiceTest.java
@@ -1,0 +1,31 @@
+package com.typesafe.conductr.bundlelib.akka;
+
+import akka.actor.ActorSystem;
+import akka.japi.Option;
+import akka.util.Timeout;
+import org.junit.Test;
+import org.scalatest.junit.JUnitSuite;
+import scala.concurrent.Await;
+import scala.concurrent.duration.Duration;
+import com.typesafe.conductr.lib.akka.ConnectionContext;
+import static org.junit.Assert.assertEquals;
+
+public class StatusServiceTest extends JUnitSuite {
+    @Test
+    public void return_None_when_running_in_development_mode() throws Exception {
+        ActorSystem system = ActorSystem.create("MySystem");
+
+        ConnectionContext cc = ConnectionContext.create(system);
+        Timeout timeout = new Timeout(Duration.create(5, "seconds"));
+
+        assertEquals(
+            Await.result(StatusService.getInstance().signalStartedOrExitWithContext(cc), timeout.duration()),
+            Option.none()
+        );
+
+        assertEquals(
+            Await.result(StatusService.getInstance().signalStartedWithContext(cc), timeout.duration()),
+            Option.none()
+        );
+    }
+}

--- a/akka24-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/EnvSpec.scala
+++ b/akka24-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/EnvSpec.scala
@@ -1,0 +1,17 @@
+package com.typesafe.conductr.bundlelib.akka
+
+import com.typesafe.conductr.lib.AkkaUnitTest
+import com.typesafe.config.ConfigException.Missing
+
+class EnvSpec extends AkkaUnitTest("EnvSpec") {
+
+  val config = Env.asConfig
+
+  "The Env functionality in the library" should {
+    "return no seed properties when running in development mode" in {
+      intercept[Missing](config.getString("akka.cluster.seed-nodes.0"))
+      intercept[Missing](config.getString("akka.remote.netty.tcp.hostname"))
+      intercept[Missing](config.getString("akka.remote.netty.tcp.port"))
+    }
+  }
+}

--- a/akka24-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/EnvSpecWithEnvForHost.scala
+++ b/akka24-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/EnvSpecWithEnvForHost.scala
@@ -1,0 +1,16 @@
+package com.typesafe.conductr.bundlelib.akka
+
+import com.typesafe.conductr.lib.AkkaUnitTest
+
+class EnvSpecWithEnvForHost extends AkkaUnitTest("EnvSpecWithEnvForHost") {
+
+  val config = Env.asConfig
+
+  "The Env functionality in the library" should {
+    "return seed properties when running with no other seed nodes" in {
+      config.getString("akka.cluster.seed-nodes.0") shouldBe "akka.tcp://some-system-v1@10.0.1.10:10000"
+      config.getString("akka.remote.netty.tcp.hostname") shouldBe "10.0.1.10"
+      config.getInt("akka.remote.netty.tcp.port") shouldBe 10000
+    }
+  }
+}

--- a/akka24-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/EnvSpecWithEnvForOneOther.scala
+++ b/akka24-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/EnvSpecWithEnvForOneOther.scala
@@ -1,0 +1,16 @@
+package com.typesafe.conductr.bundlelib.akka
+
+import com.typesafe.conductr.lib.AkkaUnitTest
+import com.typesafe.config.ConfigException.Missing
+
+class EnvSpecWithEnvForOneOther extends AkkaUnitTest("EnvSpecWithEnvForOthers") {
+
+  val config = Env.asConfig
+
+  "The Env functionality in the library" should {
+    "return seed properties when running with one other seed node" in {
+      config.getString("akka.cluster.seed-nodes.0") shouldBe "akka.udp://some-system-v1@10.0.1.11:10001"
+      intercept[Missing](config.getString("akka.cluster.seed-nodes.1"))
+    }
+  }
+}

--- a/akka24-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/EnvSpecWithEnvForOthers.scala
+++ b/akka24-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/EnvSpecWithEnvForOthers.scala
@@ -1,0 +1,17 @@
+package com.typesafe.conductr.bundlelib.akka
+
+import com.typesafe.conductr.lib.AkkaUnitTest
+import com.typesafe.config.ConfigException.Missing
+
+class EnvSpecWithEnvForOthers extends AkkaUnitTest("EnvSpecWithEnvForOthers") {
+
+  val config = Env.asConfig
+
+  "The Env functionality in the library" should {
+    "return seed properties when running with other seed nodes" in {
+      config.getString("akka.cluster.seed-nodes.0") shouldBe "akka.udp://some-system-v1@10.0.1.11:10001"
+      config.getString("akka.cluster.seed-nodes.1") shouldBe "akka.tcp://some-system-v1@10.0.1.12:10000"
+      intercept[Missing](config.getString("akka.cluster.seed-nodes.2"))
+    }
+  }
+}

--- a/akka24-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/LocationServiceSpecWithEnv.scala
+++ b/akka24-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/LocationServiceSpecWithEnv.scala
@@ -1,0 +1,123 @@
+package com.typesafe.conductr.bundlelib.akka
+
+import java.net.{ URI => JavaURI, InetSocketAddress }
+
+import akka.actor._
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.headers.{ CacheDirectives, Location, `Cache-Control` }
+import akka.http.scaladsl.model.{ HttpEntity, HttpResponse, StatusCodes }
+import akka.http.scaladsl.server.Directives._
+import akka.stream.ActorMaterializer
+import akka.testkit.TestProbe
+import com.typesafe.conductr.bundlelib.scala.{ URL, URI, CacheLike, LocationCache }
+import com.typesafe.conductr.lib.{ AkkaUnitTestWithFixture }
+import com.typesafe.conductr.lib.akka._
+import scala.concurrent.Await
+import scala.util.{ Failure, Success }
+
+class LocationServiceSpecWithEnv extends AkkaUnitTestWithFixture("LocationServiceSpecWithEnv") {
+
+  def systemFixture(f: this.FixtureParam) = new {
+    implicit val system = f.system
+    implicit val cc = ConnectionContext()
+    implicit val mat = cc.actorMaterializer
+    implicit val timeout = f.timeout
+  }
+
+  "The LocationService functionality in the library" should {
+
+    "be able to look up a named service" in { f =>
+      val sys = systemFixture(f)
+      import sys._
+
+      val serviceUri = URI("http://service_interface:4711/known")
+      withServerWithKnownService(serviceUri) {
+        val cache = LocationCache()
+        val service = LocationService.lookup("/known", URI(""), cache)
+        Await.result(service, timeout.duration) shouldBe Some(serviceUri)
+      }
+    }
+
+    "be able to look up a named service within an actor" in { f =>
+      val sys = systemFixture(f)
+      import sys._
+
+      import akka.pattern.pipe
+
+      class MyService(observer: ActorRef, cache: CacheLike) extends Actor with ImplicitConnectionContext {
+
+        import context.dispatcher
+
+        override def preStart(): Unit =
+          LocationService.lookup("/known", URI("http://127.0.0.1:9000"), cache).pipeTo(self)
+
+        override def receive: Receive = {
+          case Some(someService: JavaURI) =>
+            // We now have the service
+
+            observer ! someService
+
+          case None =>
+            self ! PoisonPill
+        }
+      }
+
+      val serviceUri = URI("http://service_interface:4711/known")
+      withServerWithKnownService(serviceUri) {
+
+        val testProbe = TestProbe()
+        val cache = LocationCache()
+
+        system.actorOf(Props(new MyService(testProbe.ref, cache)))
+        testProbe.expectMsg(serviceUri)
+      }
+    }
+  }
+
+  def withServerWithKnownService(serviceUri: JavaURI, maxAge: Option[Int] = None)(thunk: => Unit)(implicit system: ActorSystem): Unit = {
+    import system.dispatcher
+    implicit val materializer = ActorMaterializer.create(system)
+
+    val probe = new TestProbe(system)
+
+    val handler =
+      path("services" / Rest) { serviceName =>
+        get {
+          complete {
+            serviceName match {
+              case "known" =>
+                val headers = Location(serviceUri.toString) :: (maxAge match {
+                  case Some(maxAgeSecs) =>
+                    `Cache-Control`(
+                      CacheDirectives.`private`(Location.name),
+                      CacheDirectives.`max-age`(maxAgeSecs)) :: Nil
+                  case None =>
+                    Nil
+                })
+                HttpResponse(StatusCodes.TemporaryRedirect, headers, HttpEntity(s"Located at $serviceUri"))
+              case _ =>
+                HttpResponse(StatusCodes.NotFound)
+            }
+          }
+        }
+      }
+
+    val url = URL(Env.serviceLocator.get)
+    val server = Http(system).bindAndHandle(handler, url.getHost, url.getPort)
+
+    try {
+      server.onComplete {
+        case Success(binding) => probe.ref ! binding.localAddress
+        case Failure(e)       => probe.ref ! e
+      }
+
+      val address = probe.expectMsgType[InetSocketAddress]
+      address.getHostString should be(url.getHost)
+      address.getPort should be(url.getPort)
+
+      thunk
+    } finally {
+      server.foreach(_.unbind())
+    }
+  }
+}

--- a/akka24-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/StatusServiceSpecWithEnv.scala
+++ b/akka24-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/StatusServiceSpecWithEnv.scala
@@ -1,0 +1,66 @@
+package com.typesafe.conductr.bundlelib.akka
+
+import java.net.{ InetSocketAddress, URL }
+
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives._
+import akka.testkit.TestProbe
+import com.typesafe.conductr.lib.AkkaUnitTestWithFixture
+import com.typesafe.conductr.lib.akka._
+import _root_.scala.concurrent.Await
+import _root_.scala.util.{ Failure, Success }
+
+class StatusServiceSpecWithEnv extends AkkaUnitTestWithFixture("StatusServiceSpecWithEnv") {
+
+  def systemFixture(f: this.FixtureParam) = new {
+    implicit val system = f.system
+    implicit val cc = ConnectionContext()
+    implicit val mat = cc.actorMaterializer
+    implicit val timeout = f.timeout
+  }
+
+  "The StatusService functionality in the library" should {
+    "be able to call the right URL to signal that it is up" in { f =>
+      val sys = systemFixture(f)
+      import sys._
+      import system.dispatcher
+
+      val probe = new TestProbe(system)
+
+      val handler =
+        path("bundles" / Segment) { bundleId =>
+          put {
+            parameter('isStarted ! "true") {
+              complete {
+                probe.ref ! bundleId
+                StatusCodes.NoContent
+              }
+            }
+          }
+        }
+
+      val url = new URL(Env.conductRStatus.get)
+      val server = Http(system).bindAndHandle(handler, url.getHost, url.getPort)
+
+      try {
+        server.onComplete {
+          case Success(binding) => probe.ref ! binding.localAddress
+          case Failure(e)       => probe.ref ! e
+        }
+
+        val address = probe.expectMsgType[InetSocketAddress]
+        address.getHostString should be(url.getHost)
+        address.getPort should be(url.getPort)
+
+        Await.result(StatusService.signalStarted(), timeout.duration).isDefined shouldBe true
+
+        val receivedId = probe.expectMsgType[String]
+        receivedId should be(Env.bundleId.get)
+
+      } finally {
+        server.foreach(_.unbind())
+      }
+    }
+  }
+}

--- a/akka24-conductr-client-lib/build.sbt
+++ b/akka24-conductr-client-lib/build.sbt
@@ -1,0 +1,1 @@
+name := "akka24-conductr-client-lib"

--- a/build.sbt
+++ b/build.sbt
@@ -11,12 +11,18 @@ lazy val root = project
     akka23Common,
     akka23ConductRBundleLib,
     akka23ConductRClientLib,
+    akka24Common,
+    akka24ConductRBundleLib,
+    akka24ConductRClientLib,
     play23Common,
     play23ConductRBundleLib,
     play23ConductRClientLib,
     play24Common,
     play24ConductRBundleLib,
-    play24ConductRClientLib)
+    play24ConductRClientLib,
+    play25Common,
+    play25ConductRBundleLib,
+    play25ConductRClientLib)
 
 
 // Base
@@ -74,6 +80,22 @@ lazy val akka23ConductRClientLib = project
   .dependsOn(akka23Common)
   .dependsOn(scalaTestLib % "test->compile")
 
+// Akka 2.4
+lazy val akka24Common = project
+  .in(file("akka24-common"))
+  .dependsOn(scalaCommon)
+
+lazy val akka24ConductRBundleLib = project
+  .in(file("akka24-conductr-bundle-lib"))
+  .dependsOn(scalaConductRBundleLib)
+  .dependsOn(akka24Common)
+  .dependsOn(scalaTestLib % "test->compile")
+
+lazy val akka24ConductRClientLib = project
+  .in(file("akka24-conductr-client-lib"))
+  .dependsOn(scalaConductRClientLib)
+  .dependsOn(akka24Common)
+  .dependsOn(scalaTestLib % "test->compile")  
 
 // Play 2.3
 lazy val play23Common = project
@@ -110,6 +132,22 @@ lazy val play24ConductRClientLib = project
   .dependsOn(play24Common)
   .dependsOn(scalaTestLib % "test->compile")
 
+// Play 2.5
+lazy val play25Common = project
+  .in(file("play25-common"))
+  .dependsOn(scalaCommon)
+
+lazy val play25ConductRBundleLib = project
+  .in(file("play25-conductr-bundle-lib"))
+  .dependsOn(akka24ConductRBundleLib)
+  .dependsOn(play25Common)
+  .dependsOn(scalaTestLib % "test->compile")
+
+lazy val play25ConductRClientLib = project
+  .in(file("play25-conductr-client-lib"))
+  .dependsOn(scalaConductRClientLib)
+  .dependsOn(play25Common)
+  .dependsOn(scalaTestLib % "test->compile")  
 
 // Test libraries
 lazy val scalaTestLib = project

--- a/play25-common/build.sbt
+++ b/play25-common/build.sbt
@@ -1,0 +1,7 @@
+name := "play25-conductr-lib-common"
+
+libraryDependencies ++= List(
+  Library.play25Ws
+)
+
+resolvers += Resolvers.sonatypeOssSnapshot

--- a/play25-common/src/main/scala/com/typesafe/conductr/lib/play/ConnectionHandler.scala
+++ b/play25-common/src/main/scala/com/typesafe/conductr/lib/play/ConnectionHandler.scala
@@ -1,0 +1,78 @@
+package com.typesafe.conductr.lib.play
+
+import com.typesafe.conductr.lib.HttpPayload
+import com.typesafe.conductr.lib.scala.{ AbstractConnectionHandler, AbstractConnectionContext }
+import play.api.libs.ws._
+import play.api.libs.ws.ahc._
+import play.api.libs.concurrent.Execution.{ Implicits => PlayImplicits }
+import akka.stream.ActorMaterializer
+import play.api.Play
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+object ConnectionContext {
+
+  def apply(executionContext: ExecutionContext): ConnectionContext =
+    new ConnectionContext(Implicits.wsClient)(executionContext)
+
+  /** JAVA API */
+  def create(executionContext: ExecutionContext): ConnectionContext =
+    apply(executionContext)
+
+  object Implicits {
+    /**
+     * A WS client for the purposes of communicating with ConductR.
+     */
+    implicit val wsClient: WSClient = {
+      val app = Play.maybeApplication.getOrElse(
+        throw new IllegalStateException("com.typesafe.conductr.lib.play.ConnectionContext need to be used inside a Play application."))
+      val clientConfig = AhcWSClientConfig(WSClientConfig(compressionEnabled = true))
+      AhcWSClient(clientConfig)(ActorMaterializer.create(app.actorSystem))
+    }
+
+    /**
+     * An implicit defaultContext ConnectionContext.
+     * Import Implicits when you want to provide the global ConnectionContext implicitly.
+     * This global ConnectionContext uses Play's default execution context.
+     */
+    implicit val defaultContext = ConnectionContext(PlayImplicits.defaultContext)
+  }
+}
+
+/**
+ * When performing Play.WS connections, this is the connection context to use.
+ */
+class ConnectionContext(val wsClient: WSClient)(implicit val executionContext: ExecutionContext)
+  extends AbstractConnectionContext
+
+/**
+ * INTERNAL API
+ * Handles the Play.WS requests and responses
+ */
+class ConnectionHandler extends AbstractConnectionHandler {
+
+  override protected type CC = ConnectionContext
+
+  override def withConnectedRequest[T](
+    payload: Option[HttpPayload])(handler: (Int, Map[String, Option[String]]) => Option[T])(implicit cc: CC): Future[Option[T]] = {
+
+    payload.fold[Future[Option[T]]](Future.successful(None)) { p =>
+      val url = p.getUrl
+      val urlStr = url.toString
+
+      val request = cc.wsClient.url(urlStr)
+        .withHeaders("User-Agent" -> UserAgent, "Host" -> url.getHost)
+        .withMethod(p.getRequestMethod)
+        .withFollowRedirects(follow = false)
+
+      import cc.executionContext
+      request.execute().map { response =>
+        handler(
+          response.status.intValue(),
+          response.allHeaders.foldLeft(Map.empty[String, Option[String]]) {
+            case (m, (header, values)) => m.updated(header, values.lastOption)
+          })
+      }
+    }
+  }
+}

--- a/play25-conductr-bundle-lib/build.sbt
+++ b/play25-conductr-bundle-lib/build.sbt
@@ -1,0 +1,37 @@
+import Tests._
+
+name := "play25-conductr-bundle-lib"
+
+libraryDependencies ++= List(
+  Library.java8Compat,
+  Library.akka24Testkit % "test",
+  Library.play25Test    % "test",
+  Library.scalaTest     % "test"
+)
+
+resolvers ++= List(
+  Resolvers.playTypesafeReleases,
+  Resolvers.sonatypeOssSnapshot
+)  
+
+fork in Test := true
+
+def groupByFirst(tests: Seq[TestDefinition]) =
+  tests
+    .groupBy(t => t.name.drop(t.name.indexOf("WithEnv")))
+    .map {
+      case ("WithEnv", t) =>
+        new Group("WithEnv", t, SubProcess(ForkOptions(envVars = Map(
+          "BUNDLE_ID" -> "0BADF00DDEADBEEF",
+          "BUNDLE_SYSTEM" -> "somesys",
+          "BUNDLE_SYSTEM_VERSION" -> "v1",
+          "CONDUCTR_STATUS" -> "http://127.0.0.1:30007",
+          "SERVICE_LOCATOR" -> "http://127.0.0.1:30008/services",
+          "WEB_BIND_IP" -> "127.0.0.1",
+          "WEB_BIND_PORT" -> "9000"
+        ))))
+      case (x, t) =>
+        new Group("WithoutEnv", t, SubProcess(ForkOptions()))
+    }.toSeq
+
+testGrouping in Test <<= (definedTests in Test).map(groupByFirst)

--- a/play25-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/ConductRApplicationLoader.scala
+++ b/play25-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/ConductRApplicationLoader.scala
@@ -1,0 +1,22 @@
+package com.typesafe.conductr.bundlelib.play
+
+import com.typesafe.conductr.bundlelib.akka.{ Env => AkkaEnv }
+import com.typesafe.conductr.bundlelib.play.{ Env => PlayEnv }
+import play.api.inject.guice.GuiceApplicationLoader
+import play.api.{ Configuration, Application, ApplicationLoader }
+
+/**
+ * Including this class into a Play project will automatically set Play's
+ * configuration up from ConductR environment variables. Add the following
+ * to your application.conf in order to include it:
+ *
+ *    play.application.loader = "com.typesafe.conductr.bundlelib.play.ConductRApplicationLoader"
+ */
+class ConductRApplicationLoader extends ApplicationLoader {
+  def load(context: ApplicationLoader.Context): Application = {
+    val conductRConfig = Configuration(AkkaEnv.asConfig) ++ Configuration(PlayEnv.asConfig)
+    val newConfig = context.initialConfiguration ++ conductRConfig
+    val newContext = context.copy(initialConfiguration = newConfig)
+    (new GuiceApplicationLoader).load(newContext)
+  }
+}

--- a/play25-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/ConductRLifecycle.scala
+++ b/play25-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/ConductRLifecycle.scala
@@ -1,0 +1,33 @@
+package com.typesafe.conductr.bundlelib.play
+
+import play.api.inject.{ Binding, Module }
+import play.api.{ Environment, Configuration, Logger }
+import javax.inject.{ Singleton }
+import com.typesafe.conductr.lib.play.ConnectionContext
+
+/**
+ * Takes care of managing ConductR lifecycle events. In order to enable
+ * ConductR lifecycle events for your application, add the following to
+ * your application.conf:
+ *
+ *   play.modules.enabled += "com.typesafe.conductr.bundlelib.play.ConductRLifecycleModule"
+ */
+class ConductRLifecycleModule extends Module {
+
+  override def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] =
+    Seq(
+      bind(classOf[ConductRLifecycle]).toSelf.eagerly()
+    )
+}
+
+/**
+ * Responsible for signalling ConductR that the application has started.
+ */
+@Singleton
+class ConductRLifecycle {
+
+  import ConnectionContext.Implicits.defaultContext
+
+  StatusService.signalStartedOrExit()
+  Logger.info("Signalled start to ConductR")
+}

--- a/play25-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/Env.scala
+++ b/play25-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/Env.scala
@@ -1,0 +1,33 @@
+package com.typesafe.conductr.bundlelib.play
+
+import com.typesafe.conductr.bundlelib.akka.{ Env => AkkaEnv }
+
+import com.typesafe.config.{ ConfigFactory, Config }
+import scala.collection.JavaConverters._
+
+/**
+ * Provides functions to set up the Play environment in accordance with what ConductR provides.
+ */
+object Env extends com.typesafe.conductr.bundlelib.scala.Env {
+
+  /**
+   * Provides various Play related properties.
+   */
+  def asConfig: Config = {
+    val webName = sys.env.getOrElse("WEB_NAME", "WEB")
+
+    val httpAddress = sys.env.get(s"${webName}_BIND_IP").toList.map("http.address" -> _)
+    val httpPort = sys.env.get(s"${webName}_BIND_PORT").toList.map("http.port" -> _)
+
+    ConfigFactory.parseMap((httpAddress ++ httpPort ++ playActorSystem).toMap.asJava)
+  }
+
+  private def playActorSystem: List[(String, String)] =
+    (for {
+      bundleSystem <- sys.env.get("BUNDLE_SYSTEM")
+      bundleSystemVersion <- sys.env.get("BUNDLE_SYSTEM_VERSION")
+    } yield {
+      val actorSystemName = s"${AkkaEnv.mkSystemId(bundleSystem)}-${AkkaEnv.mkSystemId(bundleSystemVersion)}"
+      "play.akka.actor-system" -> actorSystemName
+    }).toList
+}

--- a/play25-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/LocationService.scala
+++ b/play25-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/LocationService.scala
@@ -1,0 +1,41 @@
+package com.typesafe.conductr.bundlelib.play
+
+import java.net.URI
+import java.util.Optional
+import java.util.concurrent.CompletionStage
+import com.typesafe.conductr.lib.play.{ ConnectionHandler, ConnectionContext }
+import com.typesafe.conductr.bundlelib.scala.{ CacheLike, AbstractLocationService }
+import play.api.libs.concurrent.Execution.Implicits
+import scala.compat.java8.OptionConverters._
+import scala.compat.java8.FutureConverters._
+
+import scala.concurrent.Future
+import scala.language.reflectiveCalls
+
+object LocationService extends LocationService(new ConnectionHandler) {
+  /** JAVA API */
+  def getInstance: LocationService =
+    LocationService
+}
+
+/**
+ * LocationService used to look up services using the Typesafe ConductR Service Locator.
+ */
+class LocationService(handler: ConnectionHandler) extends AbstractLocationService(handler) {
+  override protected type CC = ConnectionContext
+
+  override def lookup(serviceName: String, fallback: URI, cache: CacheLike)(implicit cc: CC): Future[Option[URI]] =
+    if (Env.isRunByConductR)
+      cache.getOrElseUpdate(serviceName) {
+        handler.withConnectedRequest(createLookupPayload(serviceName))(handleLookup)
+      }
+    else
+      Future.successful(Some(fallback))
+
+  /** JAVA API */
+  def lookupWithContext(serviceName: String, fallback: URI, cache: CacheLike, cc: CC): CompletionStage[Optional[URI]] = {
+    import Implicits.defaultContext
+    lookup(serviceName, fallback, cache)(cc).map(_.asJava).toJava
+  }
+
+}

--- a/play25-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/StatusService.scala
+++ b/play25-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/StatusService.scala
@@ -1,0 +1,46 @@
+package com.typesafe.conductr.bundlelib.play
+
+import java.util.Optional
+import java.util.concurrent.CompletionStage
+
+import com.typesafe.conductr.bundlelib.scala.AbstractStatusService
+import com.typesafe.conductr.lib.play.{ ConnectionHandler, ConnectionContext }
+import play.api.libs.concurrent.Execution.Implicits
+import scala.compat.java8.OptionConverters._
+import scala.compat.java8.FutureConverters._
+
+import scala.concurrent.Future
+
+object StatusService extends StatusService(new ConnectionHandler) {
+  /** JAVA API */
+  def getInstance: StatusService =
+    StatusService
+}
+
+/**
+ * StatusService used to communicate the bundle status to the Typesafe ConductR Status Server.
+ */
+class StatusService(handler: ConnectionHandler) extends AbstractStatusService(handler) {
+
+  override protected type CC = ConnectionContext
+
+  override def signalStartedOrExit()(implicit cc: CC): Future[Option[Unit]] = {
+    import Implicits.defaultContext
+    signalStarted().recover(handleSignalOrExit)
+  }
+
+  override def signalStarted()(implicit cc: CC): Future[Option[Unit]] =
+    handler.withConnectedRequest(createSignalStartedPayload)(handleSignal)
+
+  /** JAVA API */
+  def signalStartedOrExitWithContext(cc: CC): CompletionStage[Optional[Unit]] = {
+    import Implicits.defaultContext
+    signalStartedOrExit()(cc).map(_.asJava).toJava
+  }
+
+  /** JAVA API */
+  def signalStartedWithContext(cc: CC): CompletionStage[Optional[Unit]] = {
+    import Implicits.defaultContext
+    signalStarted()(cc).map(_.asJava).toJava
+  }
+}

--- a/play25-conductr-bundle-lib/src/test/java/com/typesafe/conductr/bundlelib/play/LocationServiceTest.java
+++ b/play25-conductr-bundle-lib/src/test/java/com/typesafe/conductr/bundlelib/play/LocationServiceTest.java
@@ -1,0 +1,29 @@
+package com.typesafe.conductr.bundlelib.play;
+
+import akka.util.Timeout;
+import java.util.concurrent.TimeUnit;
+import com.typesafe.conductr.bundlelib.scala.LocationCache;
+import com.typesafe.conductr.lib.play.ConnectionContext;
+import org.junit.Test;
+import play.libs.concurrent.HttpExecution;
+import play.test.WithApplication;
+import scala.concurrent.duration.Duration;
+import java.util.Optional;
+import java.net.URI;
+
+import static org.junit.Assert.assertEquals;
+
+public class LocationServiceTest extends WithApplication {
+    @Test
+    public void return_None_when_running_in_development_mode() throws Exception {
+        URI fallback = new URI("");
+        LocationCache cache = new LocationCache();
+        ConnectionContext cc = ConnectionContext.create(HttpExecution.defaultContext());
+        Timeout timeout = new Timeout(Duration.create(5, "seconds"));
+
+        assertEquals(
+            LocationService.getInstance().lookupWithContext("/whatever", fallback, cache, cc).toCompletableFuture().get(timeout.duration().toMillis(), TimeUnit.MILLISECONDS),
+            Optional.ofNullable(fallback)
+        );
+    }
+}

--- a/play25-conductr-bundle-lib/src/test/java/com/typesafe/conductr/bundlelib/play/StatusServiceTest.java
+++ b/play25-conductr-bundle-lib/src/test/java/com/typesafe/conductr/bundlelib/play/StatusServiceTest.java
@@ -1,0 +1,32 @@
+package com.typesafe.conductr.bundlelib.play;
+
+import akka.util.Timeout;
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+import java.util.Optional;
+
+import play.libs.concurrent.HttpExecution;
+import play.test.WithApplication;
+import scala.concurrent.duration.Duration;
+import com.typesafe.conductr.lib.play.ConnectionContext;
+
+import static org.junit.Assert.assertEquals;
+
+public class StatusServiceTest extends WithApplication {
+
+    @Test
+    public void return_None_when_running_in_development_mode() throws Exception {
+        ConnectionContext cc = ConnectionContext.create(HttpExecution.defaultContext());
+        Timeout timeout = new Timeout(Duration.create(5, "seconds"));
+
+        assertEquals(
+            StatusService.getInstance().signalStartedOrExitWithContext(cc).toCompletableFuture().get(timeout.duration().toMillis(), TimeUnit.MILLISECONDS),
+            Optional.empty()
+        );
+
+        assertEquals(
+            StatusService.getInstance().signalStartedWithContext(cc).toCompletableFuture().get(timeout.duration().toMillis(), TimeUnit.MILLISECONDS),
+                Optional.empty()
+        );
+    }
+}

--- a/play25-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/EnvSpecWithEnv.scala
+++ b/play25-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/EnvSpecWithEnv.scala
@@ -1,0 +1,16 @@
+package com.typesafe.conductr.bundlelib.play
+
+import com.typesafe.conductr.lib.AkkaUnitTest
+
+class EnvSpecWithEnv extends AkkaUnitTest("EnvSpecWithEnvForHost") {
+
+  val config = Env.asConfig
+
+  "The Env functionality in the library" should {
+    "initialize the env like expected" in {
+      config.getString("http.address") shouldBe "127.0.0.1"
+      config.getString("http.port") shouldBe "9000"
+      config.getString("play.akka.actor-system") shouldBe "somesys-v1"
+    }
+  }
+}

--- a/play25-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/LocationServiceSpecWithEnv.scala
+++ b/play25-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/LocationServiceSpecWithEnv.scala
@@ -1,0 +1,94 @@
+package com.typesafe.conductr.bundlelib.play
+
+import java.net.{ URI => JavaURI, InetSocketAddress }
+
+import _root_.play.api.libs.concurrent.Execution.Implicits
+import _root_.play.api.test.FakeApplication
+import _root_.play.api.test.Helpers._
+import akka.actor._
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.headers.{ CacheDirectives, Location, `Cache-Control` }
+import akka.http.scaladsl.model.{ HttpEntity, HttpResponse, StatusCodes }
+import akka.http.scaladsl.server.Directives._
+import akka.stream.ActorMaterializer
+import akka.testkit.TestProbe
+import com.typesafe.conductr.lib.play.ConnectionContext
+import play.api.libs.concurrent.Execution.{ Implicits => PlayImplicits }
+import com.typesafe.conductr.bundlelib.scala.{ URL, URI, LocationCache }
+import com.typesafe.conductr.lib._
+
+import _root_.scala.concurrent.Await
+import _root_.scala.util.{ Failure, Success }
+
+class LocationServiceSpecWithEnv extends AkkaUnitTestWithFixture("LocationServiceSpecWithEnv") {
+
+  def systemFixture(f: this.FixtureParam) = new {
+    implicit val system = f.system
+    implicit val timeout = f.timeout
+    implicit val mat = ActorMaterializer.create(system)
+  }
+
+  "The LocationService functionality in the library" should {
+
+    "be able to look up a named service" in { f =>
+      val sys = systemFixture(f)
+      import sys._
+
+      val serviceUri = URI("http://service_interface:4711/known")
+      withServerWithKnownService(serviceUri) {
+        running(FakeApplication()) {
+          implicit val cc = ConnectionContext(PlayImplicits.defaultContext)
+          val cache = LocationCache()
+          val service = LocationService.lookup("/known", URI(""), cache)
+          Await.result(service, timeout.duration) shouldBe Some(serviceUri)
+        }
+      }
+    }
+  }
+
+  def withServerWithKnownService(serviceUri: JavaURI, maxAge: Option[Int] = None)(thunk: => Unit)(implicit system: ActorSystem, mat: ActorMaterializer): Unit = {
+    import system.dispatcher
+
+    val probe = new TestProbe(system)
+
+    val handler =
+      path("services" / Rest) { serviceName =>
+        get {
+          complete {
+            serviceName match {
+              case "known" =>
+                val headers = Location(serviceUri.toString) :: (maxAge match {
+                  case Some(maxAgeSecs) =>
+                    `Cache-Control`(
+                      CacheDirectives.`private`(Location.name),
+                      CacheDirectives.`max-age`(maxAgeSecs)) :: Nil
+                  case None =>
+                    Nil
+                })
+                HttpResponse(StatusCodes.TemporaryRedirect, headers, HttpEntity(s"Located at $serviceUri"))
+              case _ =>
+                HttpResponse(StatusCodes.NotFound)
+            }
+          }
+        }
+      }
+
+    val url = URL(Env.serviceLocator.get)
+    val server = Http(system).bindAndHandle(handler, url.getHost, url.getPort)
+
+    try {
+      server.onComplete {
+        case Success(binding) => probe.ref ! binding.localAddress
+        case Failure(e)       => probe.ref ! e
+      }
+
+      val address = probe.expectMsgType[InetSocketAddress]
+      address.getHostString should be(url.getHost)
+      address.getPort should be(url.getPort)
+
+      thunk
+    } finally {
+      server.foreach(_.unbind())
+    }
+  }
+}

--- a/play25-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/StatusServiceSpecWithEnv.scala
+++ b/play25-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/StatusServiceSpecWithEnv.scala
@@ -1,0 +1,73 @@
+package com.typesafe.conductr.bundlelib.play
+
+import java.net.{ InetSocketAddress, URL }
+
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives._
+import akka.stream.ActorMaterializer
+import akka.testkit.TestProbe
+import com.typesafe.conductr.lib.play.ConnectionContext
+import play.api.libs.concurrent.Execution.{ Implicits => PlayImplicits }
+import com.typesafe.conductr.lib.{ AkkaUnitTestWithFixture }
+import play.api.test.FakeApplication
+import play.api.test.Helpers._
+
+import scala.concurrent.Await
+import scala.util.{ Failure, Success }
+
+class StatusServiceSpecWithEnv extends AkkaUnitTestWithFixture("StatusServiceSpecWithEnv") {
+
+  def systemFixture(f: this.FixtureParam) = new {
+    implicit val system = f.system
+    implicit val mat = ActorMaterializer()
+    implicit val timeout = f.timeout
+  }
+
+  "The StatusService functionality in the library" should {
+    "be able to call the right URL to signal that it is up" in { f =>
+      val sys = systemFixture(f)
+      import sys._
+      import system.dispatcher
+
+      val probe = new TestProbe(system)
+
+      val handler =
+        path("bundles" / Segment) { bundleId =>
+          put {
+            parameter('isStarted ! "true") {
+              complete {
+                probe.ref ! bundleId
+                StatusCodes.NoContent
+              }
+            }
+          }
+        }
+
+      val url = new URL(Env.conductRStatus.get)
+      val server = Http(system).bindAndHandle(handler, url.getHost, url.getPort)
+
+      try {
+        server.onComplete {
+          case Success(binding) => probe.ref ! binding.localAddress
+          case Failure(e)       => probe.ref ! e
+        }
+
+        val address = probe.expectMsgType[InetSocketAddress]
+        address.getHostString should be(url.getHost)
+        address.getPort should be(url.getPort)
+
+        running(FakeApplication()) {
+          implicit val cc = ConnectionContext(PlayImplicits.defaultContext)
+          Await.result(StatusService.signalStarted(), timeout.duration).isDefined shouldBe true
+        }
+
+        val receivedId = probe.expectMsgType[String]
+        receivedId should be(Env.bundleId.get)
+
+      } finally {
+        server.foreach(_.unbind())
+      }
+    }
+  }
+}

--- a/play25-conductr-client-lib/build.sbt
+++ b/play25-conductr-client-lib/build.sbt
@@ -1,0 +1,3 @@
+name := "play25-conductr-client-lib"
+
+resolvers += Resolvers.sonatypeOssSnapshot

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,13 +4,16 @@ import sbt.Resolver.bintrayRepo
 object Version {
   val akka23           = "2.3.14"
   val akka23Http       = "2.0.3"
-  val akkaStream       = "2.0.3"
+  val akka23Stream     = "2.0.3"
+  val akkaSse23        = "1.5.0"
   val akkaContribExtra = "2.0.2"
-  val akkaSse          = "1.5.0"
+  val akka24           = "2.4.2-RC2"
+  val akkaSse24        = "1.6.1"
   val java8Compat      = "0.7.0"
   val junit            = "4.12"
   val play23           = "2.3.9"
   val play24           = "2.4.2"
+  val play25           = "2.5.0-2016-01-27-6ec2eec-SNAPSHOT"
   val scala            = "2.11.7"
   val scalaTest        = "2.2.6"
 }
@@ -19,10 +22,16 @@ object Library {
   val akka23Cluster     = "com.typesafe.akka"      %% "akka-cluster"                   % Version.akka23
   val akka23Http        = "com.typesafe.akka"      %% "akka-http-experimental"         % Version.akka23Http
   val akka23HttpTestkit = "com.typesafe.akka"      %% "akka-http-testkit-experimental" % Version.akka23Http
-  val akkaStream        = "com.typesafe.akka"      %% "akka-stream-experimental"       % Version.akkaStream
+  val akkaStream        = "com.typesafe.akka"      %% "akka-stream-experimental"       % Version.akka23Stream
   val akka23Testkit     = "com.typesafe.akka"      %% "akka-testkit"                   % Version.akka23
+  val akkaSse23         = "de.heikoseeberger"      %% "akka-sse"                       % Version.akkaSse23
   val akkaContribExtra  = "com.typesafe.akka"      %% "akka-contrib-extra"             % Version.akkaContribExtra
-  val akkaSse           = "de.heikoseeberger"      %% "akka-sse"                       % Version.akkaSse
+  val akka24Cluster     = "com.typesafe.akka"      %% "akka-cluster"                   % Version.akka24
+  val akka24Http        = "com.typesafe.akka"      %% "akka-http-experimental"         % Version.akka24
+  val akka24HttpTestkit = "com.typesafe.akka"      %% "akka-http-testkit-experimental" % Version.akka24
+  val akka24Stream      = "com.typesafe.akka"      %% "akka-stream-experimental"       % Version.akka24
+  val akka24Testkit     = "com.typesafe.akka"      %% "akka-testkit"                   % Version.akka24
+  val akkaSse24         = "de.heikoseeberger"      %% "akka-sse"                       % Version.akkaSse24
   val java8Compat       = "org.scala-lang.modules" % "scala-java8-compat_2.11"         % Version.java8Compat
   val junit             = "junit"                  %  "junit"                          % Version.junit
   val play23Test        = "com.typesafe.play"      %% "play-test"                      % Version.play23
@@ -31,6 +40,9 @@ object Library {
   val play24Test        = "com.typesafe.play"      %% "play-test"                      % Version.play24
   val play24Ws          = "com.typesafe.play"      %% "play-ws"                        % Version.play24
   val play24Json        = "com.typesafe.play"      %% "play-json"                      % Version.play24
+  val play25Test        = "com.typesafe.play"      %% "play-test"                      % Version.play25
+  val play25Json        = "com.typesafe.play"      %% "play-json"                      % Version.play25
+  val play25Ws          = "com.typesafe.play"      %% "play-ws"                        % Version.play25
   val scalaTest         = "org.scalatest"          %% "scalatest"                      % Version.scalaTest
 }
 
@@ -38,4 +50,6 @@ object Resolvers {
   val hseeberger                 = bintrayRepo("hseeberger", "maven")
   val typesafeBintrayReleases    = bintrayRepo("typesafe", "maven-releases")
   val playTypesafeReleases       = "play-typesafe-releases" at "http://repo.typesafe.com/typesafe/maven-releases"
+  // FIXME remove this when we don't use Play 2.5 snapshot
+  val sonatypeOssSnapshot        = "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
 }


### PR DESCRIPTION
conductr-bundle-lib for Akka 2.4 (2.4-RC2) and Play 2.5 (2.5.0-2016-01-27-6ec2eec-SNAPSHOT).

These versions are the same versions Lagom is currently using.