### PR TITLE
Introduce a lib package

### DIFF
--- a/akka23-common/src/main/scala/com/typesafe/conductr/lib/akka/ConnectionHandler.scala
+++ b/akka23-common/src/main/scala/com/typesafe/conductr/lib/akka/ConnectionHandler.scala
@@ -1,4 +1,4 @@
-package com.typesafe.conductr.akka
+package com.typesafe.conductr.lib.akka
 
 import akka.actor._
 import akka.http.scaladsl.Http.OutgoingConnection
@@ -10,8 +10,8 @@ import akka.http.scaladsl.{ Http, HttpExt }
 import akka.http.scaladsl.model.headers.{ Host, `User-Agent` }
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{ Flow, Sink, Source }
-import com.typesafe.conductr.HttpPayload
-import com.typesafe.conductr.scala.{ AbstractConnectionContext, AbstractConnectionHandler }
+import com.typesafe.conductr.lib.HttpPayload
+import com.typesafe.conductr.lib.scala.{ AbstractConnectionContext, AbstractConnectionHandler }
 
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.Try

--- a/akka23-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/akka/Env.scala
+++ b/akka23-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/akka/Env.scala
@@ -27,7 +27,7 @@ object Env extends com.typesafe.conductr.bundlelib.scala.Env {
     val akkaRemoteEndpointName = sys.env.getOrElse("AKKA_REMOTE_ENDPOINT_NAME", "AKKA_REMOTE")
 
     def presentSeedNode(protocol: String, bundleSystem: String, bundleSystemVersion: String, ip: String, port: String, n: Int): (String, String) =
-      s"akka.cluster.seed-nodes.$n" -> s"akka.$protocol://${bundleSystem}-${bundleSystemVersion}@$ip:$port"
+      s"akka.cluster.seed-nodes.$n" -> s"akka.$protocol://$bundleSystem-$bundleSystemVersion@$ip:$port"
 
     val akkaSeeds = {
       val akkaSeeds =

--- a/akka23-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/akka/LocationService.scala
+++ b/akka23-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/akka/LocationService.scala
@@ -2,7 +2,7 @@ package com.typesafe.conductr.bundlelib.akka
 
 import java.net.URI
 
-import com.typesafe.conductr.akka._
+import com.typesafe.conductr.lib.akka._
 import com.typesafe.conductr.bundlelib.scala.{ CacheLike, AbstractLocationService }
 
 import akka.japi.{ Option => JOption }

--- a/akka23-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/akka/StatusService.scala
+++ b/akka23-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/akka/StatusService.scala
@@ -1,6 +1,6 @@
 package com.typesafe.conductr.bundlelib.akka
 
-import com.typesafe.conductr.akka._
+import com.typesafe.conductr.lib.akka._
 import com.typesafe.conductr.bundlelib.scala.AbstractStatusService
 
 import akka.japi.{ Option => JOption }

--- a/akka23-conductr-bundle-lib/src/test/java/com/typesafe/conductr/bundlelib/akka/LocationServiceTest.java
+++ b/akka23-conductr-bundle-lib/src/test/java/com/typesafe/conductr/bundlelib/akka/LocationServiceTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
 import scala.concurrent.Await;
 import scala.concurrent.duration.Duration;
-import com.typesafe.conductr.akka.ConnectionContext;
+import com.typesafe.conductr.lib.akka.ConnectionContext;
 
 import java.net.URI;
 

--- a/akka23-conductr-bundle-lib/src/test/java/com/typesafe/conductr/bundlelib/akka/StatusServiceTest.java
+++ b/akka23-conductr-bundle-lib/src/test/java/com/typesafe/conductr/bundlelib/akka/StatusServiceTest.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
 import scala.concurrent.Await;
 import scala.concurrent.duration.Duration;
-import com.typesafe.conductr.akka.ConnectionContext;
+import com.typesafe.conductr.lib.akka.ConnectionContext;
 import static org.junit.Assert.assertEquals;
 
 public class StatusServiceTest extends JUnitSuite {

--- a/akka23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/EnvSpec.scala
+++ b/akka23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/EnvSpec.scala
@@ -1,6 +1,6 @@
 package com.typesafe.conductr.bundlelib.akka
 
-import com.typesafe.conductr.AkkaUnitTest
+import com.typesafe.conductr.lib.AkkaUnitTest
 import com.typesafe.config.ConfigException.Missing
 
 class EnvSpec extends AkkaUnitTest("EnvSpec", "akka.loglevel = INFO") {

--- a/akka23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/EnvSpecWithEnvForHost.scala
+++ b/akka23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/EnvSpecWithEnvForHost.scala
@@ -1,6 +1,6 @@
 package com.typesafe.conductr.bundlelib.akka
 
-import com.typesafe.conductr.AkkaUnitTest
+import com.typesafe.conductr.lib.AkkaUnitTest
 
 class EnvSpecWithEnvForHost extends AkkaUnitTest("EnvSpecWithEnvForHost", "akka.loglevel = INFO") {
 

--- a/akka23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/EnvSpecWithEnvForOneOther.scala
+++ b/akka23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/EnvSpecWithEnvForOneOther.scala
@@ -1,6 +1,6 @@
 package com.typesafe.conductr.bundlelib.akka
 
-import com.typesafe.conductr.AkkaUnitTest
+import com.typesafe.conductr.lib.AkkaUnitTest
 import com.typesafe.config.ConfigException.Missing
 
 class EnvSpecWithEnvForOneOther extends AkkaUnitTest("EnvSpecWithEnvForOthers", "akka.loglevel = INFO") {

--- a/akka23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/EnvSpecWithEnvForOthers.scala
+++ b/akka23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/EnvSpecWithEnvForOthers.scala
@@ -1,6 +1,6 @@
 package com.typesafe.conductr.bundlelib.akka
 
-import com.typesafe.conductr.AkkaUnitTest
+import com.typesafe.conductr.lib.AkkaUnitTest
 import com.typesafe.config.ConfigException.Missing
 
 class EnvSpecWithEnvForOthers extends AkkaUnitTest("EnvSpecWithEnvForOthers", "akka.loglevel = INFO") {

--- a/akka23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/LocationServiceSpecWithEnv.scala
+++ b/akka23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/LocationServiceSpecWithEnv.scala
@@ -10,8 +10,8 @@ import akka.http.scaladsl.server.Directives._
 import akka.stream.ActorMaterializer
 import akka.testkit.TestProbe
 import com.typesafe.conductr.bundlelib.scala.{ URL, URI, CacheLike, LocationCache }
-import com.typesafe.conductr.{ IsolatingAkkaUnitTest }
-import com.typesafe.conductr.akka._
+import com.typesafe.conductr.lib.IsolatingAkkaUnitTest
+import com.typesafe.conductr.lib.akka._
 import scala.concurrent.Await
 import scala.util.{ Failure, Success }
 

--- a/akka23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/StatusServiceSpecWithEnv.scala
+++ b/akka23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/StatusServiceSpecWithEnv.scala
@@ -6,8 +6,8 @@ import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives._
 import akka.testkit.TestProbe
-import com.typesafe.conductr.IsolatingAkkaUnitTest
-import com.typesafe.conductr.akka._
+import com.typesafe.conductr.lib.IsolatingAkkaUnitTest
+import com.typesafe.conductr.lib.akka._
 import _root_.scala.concurrent.Await
 import _root_.scala.util.{ Failure, Success }
 

--- a/akka23-conductr-client-lib/src/main/scala/com/typesafe/conductr/clientlib/akka/ControlClient.scala
+++ b/akka23-conductr-client-lib/src/main/scala/com/typesafe/conductr/clientlib/akka/ControlClient.scala
@@ -2,16 +2,16 @@ package com.typesafe.conductr.clientlib.akka
 
 import java.io._
 import java.net.{ URI, URL }
-import java.util.zip.{ ZipFile, ZipInputStream }
+import java.util.zip.ZipInputStream
 
 import akka.http.scaladsl.marshalling.Marshal
 import akka.http.scaladsl.model.HttpEntity.IndefiniteLength
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.unmarshalling.{ PredefinedFromEntityUnmarshallers, Unmarshal }
-import akka.stream.scaladsl.{ Sink, Source, StreamConverters }
+import akka.stream.scaladsl.{ Source, StreamConverters }
 import akka.util.ByteString
-import com.typesafe.conductr.HttpPayload
-import com.typesafe.conductr.akka.{ ConnectionContext, ConnectionHandler }
+import com.typesafe.conductr.lib.HttpPayload
+import com.typesafe.conductr.lib.akka.{ ConnectionContext, ConnectionHandler }
 import com.typesafe.conductr.clientlib.akka.models._
 import com.typesafe.conductr.clientlib.scala.models._
 import com.typesafe.conductr.clientlib.scala.AbstractControlClient

--- a/akka23-conductr-client-lib/src/main/scala/com/typesafe/conductr/clientlib/akka/JsonMarshalling.scala
+++ b/akka23-conductr-client-lib/src/main/scala/com/typesafe/conductr/clientlib/akka/JsonMarshalling.scala
@@ -8,9 +8,9 @@ import akka.http.scaladsl.marshalling._
 import akka.http.scaladsl.model.MediaTypes
 import akka.http.scaladsl.unmarshalling._
 import akka.stream.ActorMaterializer
-import com.typesafe.conductr.clientlib.akka.models.{ EventStreamFailure }
+import com.typesafe.conductr.clientlib.akka.models.EventStreamFailure
 import com.typesafe.conductr.clientlib.scala.models._
-import com.typesafe.conductr.scala.ConductrTypeOps
+import com.typesafe.conductr.lib.scala.ConductrTypeOps
 import play.api.data.validation.ValidationError
 import play.api.libs.json._
 import play.api.libs.json.Reads._

--- a/akka23-conductr-client-lib/src/test/scala/com/typesafe/conductr/clientlib/akka/ControlClientSpec.scala
+++ b/akka23-conductr-client-lib/src/test/scala/com/typesafe/conductr/clientlib/akka/ControlClientSpec.scala
@@ -10,8 +10,8 @@ import akka.http.scaladsl.Http
 import akka.http.scaladsl.server.Route
 import akka.stream.actor.ActorPublisher
 import akka.stream.scaladsl.{ Flow, Keep, Sink, Source }
-import com.typesafe.conductr.{ IsolatingAkkaUnitTest }
-import com.typesafe.conductr.akka.ConnectionContext
+import com.typesafe.conductr.lib.IsolatingAkkaUnitTest
+import com.typesafe.conductr.lib.akka.ConnectionContext
 import com.typesafe.conductr.clientlib.akka.models.{ EventStreamFailure, EventStreamSuccess }
 import com.typesafe.conductr.clientlib.scala.models._
 

--- a/akka23-conductr-client-lib/src/test/scala/com/typesafe/conductr/clientlib/akka/TestData.scala
+++ b/akka23-conductr-client-lib/src/test/scala/com/typesafe/conductr/clientlib/akka/TestData.scala
@@ -1,9 +1,9 @@
 package com.typesafe.conductr.clientlib.akka
 
 import java.net.{ URL, URI }
-import java.util.{ UUID }
+import java.util.UUID
 import com.typesafe.conductr.clientlib.scala.models._
-import com.typesafe.conductr.scala.ConductrTypeOps
+import com.typesafe.conductr.lib.scala.ConductrTypeOps
 import java.util.Date
 import scala.collection.immutable.SortedSet
 

--- a/common/src/main/java/com/typesafe/conductr/lib/HttpPayload.java
+++ b/common/src/main/java/com/typesafe/conductr/lib/HttpPayload.java
@@ -1,4 +1,4 @@
-package com.typesafe.conductr;
+package com.typesafe.conductr.lib;
 
 import java.net.URL;
 

--- a/common/src/test/scala/com.typesafe.conductr.lib/HttpPayloadSpec.scala
+++ b/common/src/test/scala/com.typesafe.conductr.lib/HttpPayloadSpec.scala
@@ -1,4 +1,4 @@
-package com.typesafe.conductr
+package com.typesafe.conductr.lib
 
 import _root_.java.net.URL
 

--- a/conductr-bundle-lib/src/main/java/com/typesafe/conductr/bundlelib/LocationService.java
+++ b/conductr-bundle-lib/src/main/java/com/typesafe/conductr/bundlelib/LocationService.java
@@ -2,7 +2,7 @@ package com.typesafe.conductr.bundlelib;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import com.typesafe.conductr.HttpPayload;
+import com.typesafe.conductr.lib.HttpPayload;
 import static com.typesafe.conductr.bundlelib.Env.*;
 
 /**

--- a/conductr-bundle-lib/src/main/java/com/typesafe/conductr/bundlelib/StatusService.java
+++ b/conductr-bundle-lib/src/main/java/com/typesafe/conductr/bundlelib/StatusService.java
@@ -2,7 +2,7 @@ package com.typesafe.conductr.bundlelib;
 
 import java.io.IOException;
 import java.net.URL;
-import com.typesafe.conductr.HttpPayload;
+import com.typesafe.conductr.lib.HttpPayload;
 import static com.typesafe.conductr.bundlelib.Env.*;
 
 /**

--- a/conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/LocationServiceSpec.scala
+++ b/conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/LocationServiceSpec.scala
@@ -2,7 +2,7 @@ package com.typesafe.conductr.bundlelib
 
 import java.net.URL
 
-import com.typesafe.conductr.UnitTest
+import com.typesafe.conductr.lib.UnitTest
 
 class LocationServiceSpec extends UnitTest {
 

--- a/conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/StatusServiceSpec.scala
+++ b/conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/StatusServiceSpec.scala
@@ -1,6 +1,6 @@
 package com.typesafe.conductr.bundlelib
 
-import com.typesafe.conductr.UnitTest
+import com.typesafe.conductr.lib.UnitTest
 
 class StatusServiceSpec extends UnitTest {
 

--- a/java-common/src/main/java/com/typesafe/conductr/lib/java/ConnectionHandler.java
+++ b/java-common/src/main/java/com/typesafe/conductr/lib/java/ConnectionHandler.java
@@ -1,6 +1,6 @@
-package com.typesafe.conductr.java;
+package com.typesafe.conductr.lib.java;
 
-import com.typesafe.conductr.HttpPayload;
+import com.typesafe.conductr.lib.HttpPayload;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -13,7 +13,7 @@ import java.util.concurrent.Executor;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
-import static com.typesafe.conductr.java.ManagedBlocker.*;
+import static com.typesafe.conductr.lib.java.ManagedBlocker.*;
 
 /**
  * Connection handlers provide the means to establish a connection, issue a request and then finalize

--- a/java-common/src/main/java/com/typesafe/conductr/lib/java/ManagedBlocker.java
+++ b/java-common/src/main/java/com/typesafe/conductr/lib/java/ManagedBlocker.java
@@ -1,4 +1,4 @@
-package com.typesafe.conductr.java;
+package com.typesafe.conductr.lib.java;
 
 import java.io.UncheckedIOException;
 import java.util.concurrent.ForkJoinPool;

--- a/java-common/src/main/java/com/typesafe/conductr/lib/java/Tuple.java
+++ b/java-common/src/main/java/com/typesafe/conductr/lib/java/Tuple.java
@@ -1,4 +1,4 @@
-package com.typesafe.conductr.java;
+package com.typesafe.conductr.lib.java;
 
 /**
  * Play's Tuple class given Java 8's lack of it.

--- a/java-common/src/main/java/com/typesafe/conductr/lib/java/Unit.java
+++ b/java-common/src/main/java/com/typesafe/conductr/lib/java/Unit.java
@@ -1,4 +1,4 @@
-package com.typesafe.conductr.java;
+package com.typesafe.conductr.lib.java;
 
 /**
  * As per Scala's Unit, think of it as a Void that has a value.

--- a/java-conductr-bundle-lib/src/main/java/com/typesafe/conductr/bundlelib/java/CacheLike.java
+++ b/java-conductr-bundle-lib/src/main/java/com/typesafe/conductr/bundlelib/java/CacheLike.java
@@ -1,6 +1,6 @@
 package com.typesafe.conductr.bundlelib.java;
 
-import com.typesafe.conductr.java.Tuple;
+import com.typesafe.conductr.lib.java.Tuple;
 
 import java.time.Duration;
 import java.util.concurrent.CompletionStage;

--- a/java-conductr-bundle-lib/src/main/java/com/typesafe/conductr/bundlelib/java/LocationCache.java
+++ b/java-conductr-bundle-lib/src/main/java/com/typesafe/conductr/bundlelib/java/LocationCache.java
@@ -1,6 +1,6 @@
 package com.typesafe.conductr.bundlelib.java;
 
-import com.typesafe.conductr.java.Tuple;
+import com.typesafe.conductr.lib.java.Tuple;
 
 import java.net.URI;
 import java.time.Duration;

--- a/java-conductr-bundle-lib/src/main/java/com/typesafe/conductr/bundlelib/java/LocationService.java
+++ b/java-conductr-bundle-lib/src/main/java/com/typesafe/conductr/bundlelib/java/LocationService.java
@@ -13,9 +13,9 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.typesafe.conductr.HttpPayload;
-import com.typesafe.conductr.java.ConnectionHandler;
-import com.typesafe.conductr.java.Tuple;
+import com.typesafe.conductr.lib.HttpPayload;
+import com.typesafe.conductr.lib.java.ConnectionHandler;
+import com.typesafe.conductr.lib.java.Tuple;
 
 /**
  * A Location Service is used to look up services using the Typesafe ConductR Service Locator.

--- a/java-conductr-bundle-lib/src/main/java/com/typesafe/conductr/bundlelib/java/StatusService.java
+++ b/java-conductr-bundle-lib/src/main/java/com/typesafe/conductr/bundlelib/java/StatusService.java
@@ -7,9 +7,9 @@ import java.util.concurrent.CompletionStage;
 import java.util.Optional;
 import java.util.concurrent.ForkJoinPool;
 
-import com.typesafe.conductr.java.ConnectionHandler;
-import com.typesafe.conductr.HttpPayload;
-import com.typesafe.conductr.java.Unit;
+import com.typesafe.conductr.lib.java.ConnectionHandler;
+import com.typesafe.conductr.lib.HttpPayload;
+import com.typesafe.conductr.lib.java.Unit;
 
 /**
  * StatusService used to communicate the bundle status to the Typesafe ConductR Status Server.

--- a/java-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/java/LocationCacheSpec.scala
+++ b/java-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/java/LocationCacheSpec.scala
@@ -5,11 +5,11 @@ import java.time.{ Duration => JavaDuration }
 import java.util.Optional
 import java.util.concurrent.{ CompletableFuture, CompletionStage }
 
-import com.typesafe.conductr.AkkaUnitTest
+import com.typesafe.conductr.lib.AkkaUnitTest
 
 import scala.compat.java8.FunctionConverters._
 
-import com.typesafe.conductr.java._
+import com.typesafe.conductr.lib.java._
 
 class LocationCacheSpec extends AkkaUnitTest {
 

--- a/java-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/java/LocationServiceSpec.scala
+++ b/java-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/java/LocationServiceSpec.scala
@@ -3,8 +3,8 @@ package com.typesafe.conductr.bundlelib.java
 import java.net.{ URL, URI }
 import java.util.Optional
 
-import com.typesafe.conductr.AkkaUnitTest
-import com.typesafe.conductr.java.Await
+import com.typesafe.conductr.lib.AkkaUnitTest
+import com.typesafe.conductr.lib.java.Await
 
 class LocationServiceSpec extends AkkaUnitTest {
 

--- a/java-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/java/LocationServiceSpecWithEnv.scala
+++ b/java-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/java/LocationServiceSpecWithEnv.scala
@@ -10,8 +10,8 @@ import akka.http.scaladsl.model.{ HttpEntity, HttpResponse, StatusCodes, Uri }
 import akka.http.scaladsl.server.Directives._
 import akka.stream.ActorMaterializer
 import akka.testkit.TestProbe
-import com.typesafe.conductr.{ IsolatingAkkaUnitTest }
-import com.typesafe.conductr.java.Await
+import com.typesafe.conductr.lib.IsolatingAkkaUnitTest
+import com.typesafe.conductr.lib.java.Await
 
 import scala.util.{ Failure, Success }
 

--- a/java-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/java/StatusServiceSpec.scala
+++ b/java-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/java/StatusServiceSpec.scala
@@ -2,8 +2,8 @@ package com.typesafe.conductr.bundlelib.java
 
 import java.util.Optional
 
-import com.typesafe.conductr.AkkaUnitTest
-import com.typesafe.conductr.java._
+import com.typesafe.conductr.lib.AkkaUnitTest
+import com.typesafe.conductr.lib.java._
 
 class StatusServiceSpec extends AkkaUnitTest("StatusServiceSpec", "akka.loglevel = INFO") {
 

--- a/java-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/java/StatusServiceSpecWithEnv.scala
+++ b/java-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/java/StatusServiceSpecWithEnv.scala
@@ -7,8 +7,8 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives._
 import akka.stream.ActorMaterializer
 import akka.testkit.TestProbe
-import com.typesafe.conductr.{ IsolatingAkkaUnitTest }
-import com.typesafe.conductr.java.Await
+import com.typesafe.conductr.lib.IsolatingAkkaUnitTest
+import com.typesafe.conductr.lib.java.Await
 
 import scala.util.{ Failure, Success }
 

--- a/java-test-lib/src/main/scala/com/typesafe/conductr/lib/java/Await.scala
+++ b/java-test-lib/src/main/scala/com/typesafe/conductr/lib/java/Await.scala
@@ -1,4 +1,4 @@
-package com.typesafe.conductr.java
+package com.typesafe.conductr.lib.java
 
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.CompletionStage

--- a/play23-common/src/main/scala/com/typesafe/conductr/lib/play/ConnectionHandler.scala
+++ b/play23-common/src/main/scala/com/typesafe/conductr/lib/play/ConnectionHandler.scala
@@ -1,10 +1,10 @@
-package com.typesafe.conductr.play
+package com.typesafe.conductr.lib.play
 
 import com.ning.http.client.AsyncHttpClientConfig
-import com.typesafe.conductr.HttpPayload
-import com.typesafe.conductr.scala.{ AbstractConnectionHandler, AbstractConnectionContext }
-import play.api.libs.ws.ning.{ NingWSClientConfig, NingWSClient, NingAsyncHttpClientConfigBuilder }
-import play.api.libs.ws.WSClient
+import com.typesafe.conductr.lib.HttpPayload
+import com.typesafe.conductr.lib.scala.{ AbstractConnectionHandler, AbstractConnectionContext }
+import play.api.libs.ws.ning.{ NingWSClient, NingAsyncHttpClientConfigBuilder }
+import play.api.libs.ws.{ DefaultWSClientConfig, WSClient }
 import play.api.libs.concurrent.Execution.{ Implicits => PlayImplicits }
 
 import scala.concurrent.{ ExecutionContext, Future }
@@ -22,9 +22,9 @@ object ConnectionContext {
      * A WS client for the purposes of communicating with ConductR.
      */
     implicit val wsClient = {
-      val ningClientConfig = new NingAsyncHttpClientConfigBuilder(new NingWSClientConfig()).build()
+      val ningClientConfig = new NingAsyncHttpClientConfigBuilder(new DefaultWSClientConfig()).build()
       val clientConfig = new AsyncHttpClientConfig.Builder(ningClientConfig)
-        .setCompressionEnforced(true)
+        .setCompressionEnabled(true)
         .build()
       new NingWSClient(clientConfig)
     }

--- a/play23-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/LocationService.scala
+++ b/play23-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/LocationService.scala
@@ -1,7 +1,7 @@
 package com.typesafe.conductr.bundlelib.play
 
 import java.net.URI
-import com.typesafe.conductr.play.{ ConnectionContext, ConnectionHandler }
+import com.typesafe.conductr.lib.play.{ ConnectionContext, ConnectionHandler }
 import com.typesafe.conductr.bundlelib.scala.{ CacheLike, AbstractLocationService }
 import play.api.libs.concurrent.Execution.Implicits
 import play.libs.F

--- a/play23-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/StatusService.scala
+++ b/play23-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/StatusService.scala
@@ -1,7 +1,7 @@
 package com.typesafe.conductr.bundlelib.play
 
 import com.typesafe.conductr.bundlelib.scala.AbstractStatusService
-import com.typesafe.conductr.play.{ ConnectionContext, ConnectionHandler }
+import com.typesafe.conductr.lib.play.{ ConnectionContext, ConnectionHandler }
 import play.api.libs.concurrent.Execution.Implicits
 import play.libs.F
 

--- a/play23-conductr-bundle-lib/src/test/java/com/typesafe/conductr/bundlelib/play/LocationServiceTest.java
+++ b/play23-conductr-bundle-lib/src/test/java/com/typesafe/conductr/bundlelib/play/LocationServiceTest.java
@@ -2,7 +2,7 @@ package com.typesafe.conductr.bundlelib.play;
 
 import akka.util.Timeout;
 import com.typesafe.conductr.bundlelib.scala.LocationCache;
-import com.typesafe.conductr.play.ConnectionContext;
+import com.typesafe.conductr.lib.play.ConnectionContext;
 import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
 import play.libs.F;

--- a/play23-conductr-bundle-lib/src/test/java/com/typesafe/conductr/bundlelib/play/StatusServiceTest.java
+++ b/play23-conductr-bundle-lib/src/test/java/com/typesafe/conductr/bundlelib/play/StatusServiceTest.java
@@ -3,12 +3,10 @@ package com.typesafe.conductr.bundlelib.play;
 import akka.util.Timeout;
 import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
-import play.Application;
 import play.libs.F;
 import play.libs.HttpExecution;
-import play.test.Helpers;
 import scala.concurrent.duration.Duration;
-import com.typesafe.conductr.play.ConnectionContext;
+import com.typesafe.conductr.lib.play.ConnectionContext;
 
 import static org.junit.Assert.assertEquals;
 

--- a/play23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/EnvSpecWithEnv.scala
+++ b/play23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/EnvSpecWithEnv.scala
@@ -1,6 +1,6 @@
 package com.typesafe.conductr.bundlelib.play
 
-import com.typesafe.conductr.AkkaUnitTest
+import com.typesafe.conductr.lib.AkkaUnitTest
 
 class EnvSpecWithEnv extends AkkaUnitTest("EnvSpecWithEnvForHost", "akka.loglevel = INFO") {
 

--- a/play23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/LocationServiceSpecWithEnv.scala
+++ b/play23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/LocationServiceSpecWithEnv.scala
@@ -9,9 +9,9 @@ import akka.http.scaladsl.model.{ HttpEntity, HttpResponse, StatusCodes }
 import akka.http.scaladsl.server.Directives._
 import akka.stream.ActorMaterializer
 import akka.testkit.TestProbe
-import com.typesafe.conductr.play.ConnectionContext.Implicits
+import com.typesafe.conductr.lib.play.ConnectionContext.Implicits
 import com.typesafe.conductr.bundlelib.scala.{ URL, URI, LocationCache }
-import com.typesafe.conductr.{ IsolatingAkkaUnitTest }
+import com.typesafe.conductr.lib.IsolatingAkkaUnitTest
 
 import scala.concurrent.Await
 import scala.util.{ Failure, Success }

--- a/play23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/StatusServiceSpecWithEnv.scala
+++ b/play23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/StatusServiceSpecWithEnv.scala
@@ -7,8 +7,8 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives._
 import akka.stream.ActorMaterializer
 import akka.testkit.TestProbe
-import com.typesafe.conductr.play.ConnectionContext.Implicits
-import com.typesafe.conductr._
+import com.typesafe.conductr.lib.play.ConnectionContext.Implicits
+import com.typesafe.conductr.lib._
 
 import _root_.scala.concurrent.Await
 import _root_.scala.util.{ Failure, Success }

--- a/play24-common/src/main/scala/com/typesafe/conductr/lib/play/ConnectionHandler.scala
+++ b/play24-common/src/main/scala/com/typesafe/conductr/lib/play/ConnectionHandler.scala
@@ -1,10 +1,10 @@
-package com.typesafe.conductr.play
+package com.typesafe.conductr.lib.play
 
 import com.ning.http.client.AsyncHttpClientConfig
-import com.typesafe.conductr.HttpPayload
-import com.typesafe.conductr.scala.{ AbstractConnectionHandler, AbstractConnectionContext }
-import play.api.libs.ws.ning.{ NingWSClient, NingAsyncHttpClientConfigBuilder }
-import play.api.libs.ws.{ DefaultWSClientConfig, WSClient }
+import com.typesafe.conductr.lib.HttpPayload
+import com.typesafe.conductr.lib.scala.{ AbstractConnectionHandler, AbstractConnectionContext }
+import play.api.libs.ws.ning.{ NingWSClientConfig, NingWSClient, NingAsyncHttpClientConfigBuilder }
+import play.api.libs.ws.WSClient
 import play.api.libs.concurrent.Execution.{ Implicits => PlayImplicits }
 
 import scala.concurrent.{ ExecutionContext, Future }
@@ -22,9 +22,9 @@ object ConnectionContext {
      * A WS client for the purposes of communicating with ConductR.
      */
     implicit val wsClient = {
-      val ningClientConfig = new NingAsyncHttpClientConfigBuilder(new DefaultWSClientConfig()).build()
+      val ningClientConfig = new NingAsyncHttpClientConfigBuilder(new NingWSClientConfig()).build()
       val clientConfig = new AsyncHttpClientConfig.Builder(ningClientConfig)
-        .setCompressionEnabled(true)
+        .setCompressionEnforced(true)
         .build()
       new NingWSClient(clientConfig)
     }

--- a/play24-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/ConductRLifecycle.scala
+++ b/play24-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/ConductRLifecycle.scala
@@ -1,6 +1,6 @@
 package com.typesafe.conductr.bundlelib.play
 
-import com.typesafe.conductr.play.ConnectionContext.Implicits
+import com.typesafe.conductr.lib.play.ConnectionContext.Implicits
 import play.api.inject.{ Binding, Module }
 import play.api.{ Environment, Configuration, Logger }
 import javax.inject.Singleton

--- a/play24-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/LocationService.scala
+++ b/play24-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/LocationService.scala
@@ -1,7 +1,7 @@
 package com.typesafe.conductr.bundlelib.play
 
 import java.net.URI
-import com.typesafe.conductr.play.{ ConnectionHandler, ConnectionContext }
+import com.typesafe.conductr.lib.play.{ ConnectionHandler, ConnectionContext }
 import com.typesafe.conductr.bundlelib.scala.{ CacheLike, AbstractLocationService }
 import play.api.libs.concurrent.Execution.Implicits
 import play.libs.F

--- a/play24-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/StatusService.scala
+++ b/play24-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/StatusService.scala
@@ -1,7 +1,7 @@
 package com.typesafe.conductr.bundlelib.play
 
 import com.typesafe.conductr.bundlelib.scala.AbstractStatusService
-import com.typesafe.conductr.play.{ ConnectionHandler, ConnectionContext }
+import com.typesafe.conductr.lib.play.{ ConnectionHandler, ConnectionContext }
 import play.api.libs.concurrent.Execution.Implicits
 import play.libs.F
 

--- a/play24-conductr-bundle-lib/src/test/java/com/typesafe/conductr/bundlelib/play/LocationServiceTest.java
+++ b/play24-conductr-bundle-lib/src/test/java/com/typesafe/conductr/bundlelib/play/LocationServiceTest.java
@@ -2,7 +2,7 @@ package com.typesafe.conductr.bundlelib.play;
 
 import akka.util.Timeout;
 import com.typesafe.conductr.bundlelib.scala.LocationCache;
-import com.typesafe.conductr.play.ConnectionContext;
+import com.typesafe.conductr.lib.play.ConnectionContext;
 import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
 import play.libs.F;

--- a/play24-conductr-bundle-lib/src/test/java/com/typesafe/conductr/bundlelib/play/StatusServiceTest.java
+++ b/play24-conductr-bundle-lib/src/test/java/com/typesafe/conductr/bundlelib/play/StatusServiceTest.java
@@ -3,12 +3,10 @@ package com.typesafe.conductr.bundlelib.play;
 import akka.util.Timeout;
 import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
-import play.Application;
 import play.libs.F;
 import play.libs.HttpExecution;
-import play.test.Helpers;
 import scala.concurrent.duration.Duration;
-import com.typesafe.conductr.play.ConnectionContext;
+import com.typesafe.conductr.lib.play.ConnectionContext;
 
 import static org.junit.Assert.assertEquals;
 

--- a/play24-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/EnvSpecWithEnv.scala
+++ b/play24-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/EnvSpecWithEnv.scala
@@ -1,6 +1,6 @@
 package com.typesafe.conductr.bundlelib.play
 
-import com.typesafe.conductr.AkkaUnitTest
+import com.typesafe.conductr.lib.AkkaUnitTest
 
 class EnvSpecWithEnv extends AkkaUnitTest("EnvSpecWithEnvForHost", "akka.loglevel = INFO") {
 

--- a/play24-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/LocationServiceSpecWithEnv.scala
+++ b/play24-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/LocationServiceSpecWithEnv.scala
@@ -9,9 +9,9 @@ import akka.http.scaladsl.model.{ HttpEntity, HttpResponse, StatusCodes }
 import akka.http.scaladsl.server.Directives._
 import akka.stream.ActorMaterializer
 import akka.testkit.TestProbe
-import com.typesafe.conductr.play.ConnectionContext.Implicits
+import com.typesafe.conductr.lib.play.ConnectionContext.Implicits
 import com.typesafe.conductr.bundlelib.scala.{ URL, URI, LocationCache }
-import com.typesafe.conductr._
+import com.typesafe.conductr.lib._
 
 import _root_.scala.concurrent.Await
 import _root_.scala.util.{ Failure, Success }

--- a/play24-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/StatusServiceSpecWithEnv.scala
+++ b/play24-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/StatusServiceSpecWithEnv.scala
@@ -7,8 +7,8 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives._
 import akka.stream.ActorMaterializer
 import akka.testkit.TestProbe
-import com.typesafe.conductr.play.ConnectionContext.Implicits
-import com.typesafe.conductr.{ IsolatingAkkaUnitTest }
+import com.typesafe.conductr.lib.play.ConnectionContext.Implicits
+import com.typesafe.conductr.lib.IsolatingAkkaUnitTest
 
 import _root_.scala.concurrent.Await
 import _root_.scala.util.{ Failure, Success }

--- a/scala-common/src/main/scala/com/typesafe/conductr/lib/scala/AbstractConnectionHandler.scala
+++ b/scala-common/src/main/scala/com/typesafe/conductr/lib/scala/AbstractConnectionHandler.scala
@@ -1,6 +1,6 @@
-package com.typesafe.conductr.scala
+package com.typesafe.conductr.lib.scala
 
-import com.typesafe.conductr.HttpPayload
+import com.typesafe.conductr.lib.HttpPayload
 import scala.concurrent.Future
 
 /**

--- a/scala-common/src/main/scala/com/typesafe/conductr/lib/scala/ConductrTypeOps.scala
+++ b/scala-common/src/main/scala/com/typesafe/conductr/lib/scala/ConductrTypeOps.scala
@@ -1,4 +1,4 @@
-package com.typesafe.conductr.scala
+package com.typesafe.conductr.lib.scala
 
 object ConductrTypeOps {
 

--- a/scala-common/src/main/scala/com/typesafe/conductr/lib/scala/ConnectionHandler.scala
+++ b/scala-common/src/main/scala/com/typesafe/conductr/lib/scala/ConnectionHandler.scala
@@ -1,8 +1,8 @@
-package com.typesafe.conductr.scala
+package com.typesafe.conductr.lib.scala
 
 import java.io.IOException
 import java.net.HttpURLConnection
-import com.typesafe.conductr.HttpPayload
+import com.typesafe.conductr.lib.HttpPayload
 import scala.concurrent._
 import scala.util.{ Failure, Success, Try }
 

--- a/scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/scala/AbstractLocationService.scala
+++ b/scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/scala/AbstractLocationService.scala
@@ -4,8 +4,8 @@ import java.io.IOException
 import java.net.{ URL => JavaURL, URI => JavaURI }
 import java.util.concurrent.TimeUnit
 
-import com.typesafe.conductr.HttpPayload
-import com.typesafe.conductr.scala.{ AbstractConnectionHandler, AbstractConnectionContext }
+import com.typesafe.conductr.lib.HttpPayload
+import com.typesafe.conductr.lib.scala.{ AbstractConnectionHandler, AbstractConnectionContext }
 import com.typesafe.conductr.bundlelib.{ LocationService => JavaLocationService }
 
 import scala.concurrent._

--- a/scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/scala/AbstractStatusService.scala
+++ b/scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/scala/AbstractStatusService.scala
@@ -2,8 +2,8 @@ package com.typesafe.conductr.bundlelib.scala
 
 import java.io.IOException
 
-import com.typesafe.conductr.HttpPayload
-import com.typesafe.conductr.scala.{ AbstractConnectionHandler, AbstractConnectionContext }
+import com.typesafe.conductr.lib.HttpPayload
+import com.typesafe.conductr.lib.scala.{ AbstractConnectionHandler, AbstractConnectionContext }
 import com.typesafe.conductr.bundlelib.{ StatusService => JavaStatusService }
 
 import scala.concurrent.Future

--- a/scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/scala/LocationService.scala
+++ b/scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/scala/LocationService.scala
@@ -2,7 +2,7 @@ package com.typesafe.conductr.bundlelib.scala
 
 import java.net.{ URI => JavaURI }
 
-import com.typesafe.conductr.scala.{ ConnectionContext, ConnectionHandler }
+import com.typesafe.conductr.lib.scala.{ ConnectionContext, ConnectionHandler }
 
 import scala.concurrent.Future
 

--- a/scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/scala/StatusService.scala
+++ b/scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/scala/StatusService.scala
@@ -1,6 +1,6 @@
 package com.typesafe.conductr.bundlelib.scala
 
-import com.typesafe.conductr.scala.{ ConnectionHandler, ConnectionContext }
+import com.typesafe.conductr.lib.scala.{ ConnectionHandler, ConnectionContext }
 
 import scala.concurrent.Future
 

--- a/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/LocationCacheSpec.scala
+++ b/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/LocationCacheSpec.scala
@@ -1,6 +1,6 @@
 package com.typesafe.conductr.bundlelib.scala
 
-import com.typesafe.conductr.AkkaUnitTest
+import com.typesafe.conductr.lib.AkkaUnitTest
 
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, Future }

--- a/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/LocationServiceSpec.scala
+++ b/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/LocationServiceSpec.scala
@@ -1,7 +1,7 @@
 package com.typesafe.conductr.bundlelib.scala
 
-import com.typesafe.conductr.AkkaUnitTest
-import com.typesafe.conductr.scala.ConnectionContext.Implicits
+import com.typesafe.conductr.lib.AkkaUnitTest
+import com.typesafe.conductr.lib.scala.ConnectionContext.Implicits
 import scala.concurrent.Await
 
 class LocationServiceSpec extends AkkaUnitTest {

--- a/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/LocationServiceSpecWithEnv.scala
+++ b/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/LocationServiceSpecWithEnv.scala
@@ -7,10 +7,10 @@ import akka.http.scaladsl.model.{ HttpEntity, Uri, HttpResponse, StatusCodes }
 import akka.http.scaladsl.server.Directives._
 import akka.stream.ActorMaterializer
 import akka.testkit.TestProbe
-import com.typesafe.conductr.{ IsolatingAkkaUnitTest }
+import com.typesafe.conductr.lib.IsolatingAkkaUnitTest
 import java.net.InetSocketAddress
 
-import com.typesafe.conductr.scala.ConnectionContext.Implicits
+import com.typesafe.conductr.lib.scala.ConnectionContext.Implicits
 
 import scala.concurrent.Await
 import scala.util.{ Failure, Success }

--- a/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/StatusServiceSpec.scala
+++ b/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/StatusServiceSpec.scala
@@ -1,7 +1,7 @@
 package com.typesafe.conductr.bundlelib.scala
 
-import com.typesafe.conductr.AkkaUnitTest
-import com.typesafe.conductr.scala.ConnectionContext.Implicits
+import com.typesafe.conductr.lib.AkkaUnitTest
+import com.typesafe.conductr.lib.scala.ConnectionContext.Implicits
 import scala.concurrent.Await
 
 class StatusServiceSpec extends AkkaUnitTest("StatusServiceSpec", "akka.loglevel = INFO") {

--- a/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/StatusServiceSpecWithEnv.scala
+++ b/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/StatusServiceSpecWithEnv.scala
@@ -5,9 +5,9 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives._
 import akka.stream.ActorMaterializer
 import akka.testkit.TestProbe
-import com.typesafe.conductr.{ IsolatingAkkaUnitTest }
+import com.typesafe.conductr.lib.IsolatingAkkaUnitTest
 import java.net.InetSocketAddress
-import com.typesafe.conductr.scala.ConnectionContext.Implicits
+import com.typesafe.conductr.lib.scala.ConnectionContext.Implicits
 
 import scala.concurrent.Await
 import scala.util.{ Failure, Success }

--- a/scala-conductr-client-lib/src/main/scala/com/typesafe/conductr/clientlib/scala/AbstractControlClient.scala
+++ b/scala-conductr-client-lib/src/main/scala/com/typesafe/conductr/clientlib/scala/AbstractControlClient.scala
@@ -1,9 +1,9 @@
 package com.typesafe.conductr.clientlib.scala
 
 import java.net.{ URLEncoder, URI, URL }
-import com.typesafe.conductr.HttpPayload
+import com.typesafe.conductr.lib.HttpPayload
 import com.typesafe.conductr.clientlib.scala.models._
-import com.typesafe.conductr.scala.AbstractConnectionContext
+import com.typesafe.conductr.lib.scala.AbstractConnectionContext
 
 import scala.concurrent.Future
 

--- a/scala-test-lib/src/main/scala/com/typesafe/conductr/lib/AkkaUnitTest.scala
+++ b/scala-test-lib/src/main/scala/com/typesafe/conductr/lib/AkkaUnitTest.scala
@@ -1,4 +1,4 @@
-package com.typesafe.conductr
+package com.typesafe.conductr.lib
 
 import akka.actor.ActorSystem
 import akka.testkit.TestKitExtension

--- a/scala-test-lib/src/main/scala/com/typesafe/conductr/lib/UnitTestLike.scala
+++ b/scala-test-lib/src/main/scala/com/typesafe/conductr/lib/UnitTestLike.scala
@@ -1,4 +1,4 @@
-package com.typesafe.conductr
+package com.typesafe.conductr.lib
 
 import org.scalatest.{ Matchers, WordSpec, WordSpecLike }
 


### PR DESCRIPTION
A lib package replaces what we had in terms of "bundlelib" before the client lib. "bundlelib" was distinguishing the conducti-lib packages from others, particularly of the conduct projects themselves. Removing the package distinction caused conflicts, particularly in IntelliJ.

Note that the 1.1 and 1.2 ConductR doco should be updated to change some references of "bundlelib" to "lib".

This should be released as 1.2.0