### PR TITLE
Accept service names with and without leading slash

### DIFF
--- a/akka23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/LocationServiceSpecWithEnv.scala
+++ b/akka23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/LocationServiceSpecWithEnv.scala
@@ -26,7 +26,7 @@ class LocationServiceSpecWithEnv extends AkkaUnitTestWithFixture("LocationServic
 
   "The LocationService functionality in the library" should {
 
-    "be able to look up a named service" in { f =>
+    "be able to look up a named service with a leading slash" in { f =>
       val sys = systemFixture(f)
       import sys._
 
@@ -34,6 +34,18 @@ class LocationServiceSpecWithEnv extends AkkaUnitTestWithFixture("LocationServic
       withServerWithKnownService(serviceUri) {
         val cache = LocationCache()
         val service = LocationService.lookup("/known", URI(""), cache)
+        Await.result(service, timeout.duration) shouldBe Some(serviceUri)
+      }
+    }
+
+    "be able to look up a named service without a leading slash" in { f =>
+      val sys = systemFixture(f)
+      import sys._
+
+      val serviceUri = URI("http://service_interface:4711/known")
+      withServerWithKnownService(serviceUri) {
+        val cache = LocationCache()
+        val service = LocationService.lookup("known", URI(""), cache)
         Await.result(service, timeout.duration) shouldBe Some(serviceUri)
       }
     }

--- a/akka24-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/LocationServiceSpecWithEnv.scala
+++ b/akka24-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/LocationServiceSpecWithEnv.scala
@@ -26,7 +26,7 @@ class LocationServiceSpecWithEnv extends AkkaUnitTestWithFixture("LocationServic
 
   "The LocationService functionality in the library" should {
 
-    "be able to look up a named service" in { f =>
+    "be able to look up a named service with a leading slash" in { f =>
       val sys = systemFixture(f)
       import sys._
 
@@ -34,6 +34,18 @@ class LocationServiceSpecWithEnv extends AkkaUnitTestWithFixture("LocationServic
       withServerWithKnownService(serviceUri) {
         val cache = LocationCache()
         val service = LocationService.lookup("/known", URI(""), cache)
+        Await.result(service, timeout.duration) shouldBe Some(serviceUri)
+      }
+    }
+
+    "be able to look up a named service without a leading slash" in { f =>
+      val sys = systemFixture(f)
+      import sys._
+
+      val serviceUri = URI("http://service_interface:4711/known")
+      withServerWithKnownService(serviceUri) {
+        val cache = LocationCache()
+        val service = LocationService.lookup("known", URI(""), cache)
         Await.result(service, timeout.duration) shouldBe Some(serviceUri)
       }
     }

--- a/conductr-bundle-lib/src/main/java/com/typesafe/conductr/bundlelib/LocationService.java
+++ b/conductr-bundle-lib/src/main/java/com/typesafe/conductr/bundlelib/LocationService.java
@@ -51,7 +51,8 @@ public class LocationService {
     }
 
     static HttpPayload createLookupPayload(String serviceLocator, String serviceName) throws MalformedURLException {
-        URL locatorUrl = new URL(serviceLocator + serviceName);
+        String serviceNameWithLeadingSlash = serviceName.startsWith("/") ? serviceName : "/" + serviceName;
+        URL locatorUrl = new URL(serviceLocator + serviceNameWithLeadingSlash);
         return new HttpPayload(locatorUrl);
     }
 }

--- a/java-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/java/LocationServiceSpecWithEnv.scala
+++ b/java-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/java/LocationServiceSpecWithEnv.scala
@@ -28,11 +28,18 @@ class LocationServiceSpecWithEnv extends AkkaUnitTestWithFixture("LocationServic
 
   "The LocationService functionality in the library" should {
 
-    "return the lookup url" in { f =>
+    "return the lookup url with a leading slash" in { f =>
       val sys = systemFixture(f)
       import sys._
 
       LocationService.getLookupUrl("/whatever", new URL("http://127.0.0.1/whatever")) shouldBe new URL("http://127.0.0.1:20008/services/whatever")
+    }
+
+    "return the lookup url without a leading slash" in { f =>
+      val sys = systemFixture(f)
+      import sys._
+
+      LocationService.getLookupUrl("whatever", new URL("http://127.0.0.1/whatever")) shouldBe new URL("http://127.0.0.1:20008/services/whatever")
     }
 
     "be able to look up a named service" in { f =>

--- a/play23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/LocationServiceSpecWithEnv.scala
+++ b/play23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/LocationServiceSpecWithEnv.scala
@@ -27,7 +27,7 @@ class LocationServiceSpecWithEnv extends AkkaUnitTestWithFixture("LocationServic
 
   "The LocationService functionality in the library" should {
 
-    "be able to look up a named service" in { f =>
+    "be able to look up a named service with a leading slash" in { f =>
       val sys = systemFixture(f)
       import sys._
 
@@ -35,6 +35,18 @@ class LocationServiceSpecWithEnv extends AkkaUnitTestWithFixture("LocationServic
       withServerWithKnownService(serviceUri) {
         val cache = LocationCache()
         val service = LocationService.lookup("/known", URI(""), cache)
+        Await.result(service, timeout.duration) shouldBe Some(serviceUri)
+      }
+    }
+
+    "be able to look up a named service without a leading slash" in { f =>
+      val sys = systemFixture(f)
+      import sys._
+
+      val serviceUri = URI("http://service_interface:4711/known")
+      withServerWithKnownService(serviceUri) {
+        val cache = LocationCache()
+        val service = LocationService.lookup("known", URI(""), cache)
         Await.result(service, timeout.duration) shouldBe Some(serviceUri)
       }
     }

--- a/play24-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/LocationServiceSpecWithEnv.scala
+++ b/play24-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/LocationServiceSpecWithEnv.scala
@@ -27,7 +27,7 @@ class LocationServiceSpecWithEnv extends AkkaUnitTestWithFixture("LocationServic
 
   "The LocationService functionality in the library" should {
 
-    "be able to look up a named service" in { f =>
+    "be able to look up a named service with a leading slash" in { f =>
       val sys = systemFixture(f)
       import sys._
 
@@ -35,6 +35,18 @@ class LocationServiceSpecWithEnv extends AkkaUnitTestWithFixture("LocationServic
       withServerWithKnownService(serviceUri) {
         val cache = LocationCache()
         val service = LocationService.lookup("/known", URI(""), cache)
+        Await.result(service, timeout.duration) shouldBe Some(serviceUri)
+      }
+    }
+
+    "be able to look up a named service without a leading slash" in { f =>
+      val sys = systemFixture(f)
+      import sys._
+
+      val serviceUri = URI("http://service_interface:4711/known")
+      withServerWithKnownService(serviceUri) {
+        val cache = LocationCache()
+        val service = LocationService.lookup("known", URI(""), cache)
         Await.result(service, timeout.duration) shouldBe Some(serviceUri)
       }
     }

--- a/play25-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/api/LocationServiceSpecWithEnv.scala
+++ b/play25-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/api/LocationServiceSpecWithEnv.scala
@@ -27,7 +27,7 @@ class LocationServiceSpecWithEnv extends AkkaUnitTestWithFixture("LocationServic
 
   "The LocationService functionality in the library" should {
 
-    "be able to look up a named service" in { f =>
+    "be able to look up a named service with a leading slash" in { f =>
       val sys = systemFixture(f)
       import sys._
 
@@ -40,6 +40,24 @@ class LocationServiceSpecWithEnv extends AkkaUnitTestWithFixture("LocationServic
           val cache = app.injector.instanceOf[CacheLike]
           val locationService = app.injector.instanceOf[LocationService]
           val service = locationService.lookup("/known", URI(""), cache)
+          Await.result(service, timeout.duration) shouldBe Some(serviceUri)
+        }
+      }
+    }
+
+    "be able to look up a named service without a leading slash" in { f =>
+      val sys = systemFixture(f)
+      import sys._
+
+      val serviceUri = URI("http://service_interface:4711/known")
+      val app = new GuiceApplicationBuilder()
+        .bindings(new BundlelibModule)
+        .build()
+      withServerWithKnownService(serviceUri) {
+        running(app) {
+          val cache = app.injector.instanceOf[CacheLike]
+          val locationService = app.injector.instanceOf[LocationService]
+          val service = locationService.lookup("known", URI(""), cache)
           Await.result(service, timeout.duration) shouldBe Some(serviceUri)
         }
       }

--- a/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/LocationServiceSpecWithEnv.scala
+++ b/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/LocationServiceSpecWithEnv.scala
@@ -25,11 +25,18 @@ class LocationServiceSpecWithEnv extends AkkaUnitTestWithFixture("LocationServic
   }
 
   "The LocationService functionality in the library" should {
-    "return the lookup url" in { f =>
+    "return the lookup url with leading slash" in { f =>
       val sys = systemFixture(f)
       import sys._
 
       LocationService.getLookupUrl("/whatever", URL("http://127.0.0.1/whatever")) shouldBe URL("http://127.0.0.1:50008/services/whatever")
+    }
+
+    "return the lookup url without leading slash" in { f =>
+      val sys = systemFixture(f)
+      import sys._
+
+      LocationService.getLookupUrl("whatever", URL("http://127.0.0.1/whatever")) shouldBe URL("http://127.0.0.1:50008/services/whatever")
     }
 
     "be able to look up a named service" in { f =>


### PR DESCRIPTION
So far service names needed to start with a `/`. This change makes it possible that services names with and without a leading slash can be resolved.

Fixes issue: https://github.com/typesafehub/conductr-lib/issues/70