### PR TITLE
Provide reference.conf for Play libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,11 +287,6 @@ Note that your `application.conf` should contain the following (for Scala):
 
 ```
 play.application.loader = "com.typesafe.conductr.bundlelib.play.lib.ConductRApplicationLoader"
-
-play.modules {
-  enabled += "com.typesafe.conductr.bundlelib.play.api.BundlelibModule"
-  enabled += "com.typesafe.conductr.bundlelib.play.api.ConductRLifecycleModule"
-}
 ```
 
 For Java, just change the `play.api` to `play` in the above.
@@ -369,8 +364,6 @@ Your `application.conf` should contain the following:
 
 ```
 play.application.loader = "com.typesafe.conductr.bundlelib.play.ConductRApplicationLoader"
-
-play.modules.enabled += "com.typesafe.conductr.bundlelib.play.ConductRLifecycleModule"
 ```
 
 Note that if you are using your own application loader then you should ensure that the Akka and Play ConductR-related properties are loaded. Here's a complete implementation:

--- a/play24-conductr-bundle-lib/src/main/resources/reference.conf
+++ b/play24-conductr-bundle-lib/src/main/resources/reference.conf
@@ -1,0 +1,10 @@
+#######################################
+# Play ConductR Reference Config File #
+#######################################
+
+# This is the reference config file that contains all the default settings.
+# Make your edits/overrides in your application.conf.
+
+# Enables the Play `ConductRLifecycleModule`
+# to signal ConductR that the Play application has been started
+play.modules.enabled += "com.typesafe.conductr.bundlelib.play.ConductRLifecycleModule"

--- a/play25-conductr-bundle-lib/src/main/resources/reference.conf
+++ b/play25-conductr-bundle-lib/src/main/resources/reference.conf
@@ -1,0 +1,15 @@
+#######################################
+# Play ConductR Reference Config File #
+#######################################
+
+# This is the reference config file that contains all the default settings.
+# Make your edits/overrides in your application.conf.
+
+play.modules {
+  # Enables the Play `BundlelibModule` to make the ConductR services injectable
+  enabled += "com.typesafe.conductr.bundlelib.play.api.BundlelibModule"
+
+  # Enables the Play `ConductRLifecycleModule`
+  # to signal ConductR that the Play application has been started
+  enabled += "com.typesafe.conductr.bundlelib.play.api.ConductRLifecycleModule"
+}

--- a/play25-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/api/LocationServiceSpecWithEnv.scala
+++ b/play25-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/api/LocationServiceSpecWithEnv.scala
@@ -34,6 +34,7 @@ class LocationServiceSpecWithEnv extends AkkaUnitTestWithFixture("LocationServic
       val serviceUri = URI("http://service_interface:4711/known")
       val app = new GuiceApplicationBuilder()
         .bindings(new BundlelibModule)
+        .disable(classOf[ConductRLifecycleModule])
         .build()
       withServerWithKnownService(serviceUri) {
         running(app) {
@@ -52,6 +53,7 @@ class LocationServiceSpecWithEnv extends AkkaUnitTestWithFixture("LocationServic
       val serviceUri = URI("http://service_interface:4711/known")
       val app = new GuiceApplicationBuilder()
         .bindings(new BundlelibModule)
+        .disable(classOf[ConductRLifecycleModule])
         .build()
       withServerWithKnownService(serviceUri) {
         running(app) {

--- a/play25-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/api/StatusServiceSpecWithEnv.scala
+++ b/play25-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/api/StatusServiceSpecWithEnv.scala
@@ -58,6 +58,7 @@ class StatusServiceSpecWithEnv extends AkkaUnitTestWithFixture("StatusServiceSpe
 
         val app = new GuiceApplicationBuilder()
           .bindings(new BundlelibModule)
+          .disable(classOf[ConductRLifecycleModule])
           .build()
         running(app) {
           val statusService = app.injector.instanceOf(classOf[StatusService])


### PR DESCRIPTION
Provides `reference.conf` for Play 2.4 and Play 2.5 `conductr-bundle-lib`. Therefore the user doesn't need to specify the Play modules in its own `application.conf` anymore.

This PR has been acceptance tested with the sample project `conductr-service-lookup`.

Fixes https://github.com/typesafehub/conductr-lib/issues/78.