### PR TITLE
Set default application loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,14 +283,6 @@ The following components are available for injection:
 * LocationService
 * StatusService
 
-Note that your `application.conf` should contain the following (for Scala):
-
-```
-play.application.loader = "com.typesafe.conductr.bundlelib.play.lib.ConductRApplicationLoader"
-```
-
-For Java, just change the `play.api` to `play` in the above.
-
 Note that if you are using your own application loader then you should ensure that the Akka and Play ConductR-related properties are loaded. Here's a complete implementation (for Scala):
 
 ```scala
@@ -359,12 +351,6 @@ In order for an application or service to take advantage of setting important Pl
 
 
 #### Play 2.4
-
-Your `application.conf` should contain the following:
-
-```
-play.application.loader = "com.typesafe.conductr.bundlelib.play.ConductRApplicationLoader"
-```
 
 Note that if you are using your own application loader then you should ensure that the Akka and Play ConductR-related properties are loaded. Here's a complete implementation:
 

--- a/play24-conductr-bundle-lib/src/main/resources/play/reference-overrides.conf
+++ b/play24-conductr-bundle-lib/src/main/resources/play/reference-overrides.conf
@@ -1,0 +1,11 @@
+# Hack to override some of Play's defaults
+
+# ConductR's config file loading logic will load this file with a higher
+# priority than reference.conf, but a lower priority than application.conf.
+# That allows ConductR to override Play's reference.conf (which can't happen
+# from in ConductR's own reference.conf), but still allow users to override
+# ConductR's settings in their application.conf.
+
+
+# Custom ConductR Application loader to load ConductR related configurations
+play.application.loader = "com.typesafe.conductr.bundlelib.play.ConductRApplicationLoader"

--- a/play25-conductr-bundle-lib/src/main/resources/play/reference-overrides.conf
+++ b/play25-conductr-bundle-lib/src/main/resources/play/reference-overrides.conf
@@ -1,0 +1,11 @@
+# Hack to override some of Play's defaults
+
+# ConductR's config file loading logic will load this file with a higher
+# priority than reference.conf, but a lower priority than application.conf.
+# That allows ConductR to override Play's reference.conf (which can't happen
+# from in ConductR's own reference.conf), but still allow users to override
+# ConductR's settings in their application.conf.
+
+
+# Custom ConductR Application loader to load ConductR related configurations
+play.application.loader = "com.typesafe.conductr.bundlelib.play.api.ConductRApplicationLoader"


### PR DESCRIPTION
Set the default ConductR application loader for Play 2.4 and Play 2.5. This makes it obsolete that the user need to specify the application loader in the `application.conf`. Note that it is still possible to specify a custom application loader by specifying them in the `application.conf`.