### PR TITLE
Use Service Locator only in Prod mode

### DIFF
--- a/lagom10-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/lagom/ServiceLocatorModule.scala
+++ b/lagom10-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/lagom/ServiceLocatorModule.scala
@@ -3,16 +3,19 @@ package com.typesafe.conductr.bundlelib.lagom
 import javax.inject.Singleton
 
 import com.lightbend.lagom.javadsl.api.ServiceLocator
-import play.api.{ Configuration, Environment }
+import play.api.{ Configuration, Environment, Mode }
 import play.api.inject.{ Binding, Module }
 
 /**
  * This module binds the ServiceLocator interface from Lagom to the `ConductRServiceLocator`
+ * The `ConductRServiceLocator` is only bound if the application has been started in `Prod` mode.
+ * In `Dev` mode the embedded service locator of Lagom is used.  
  */
 class ServiceLocatorModule extends Module {
 
   override def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] =
-    Seq(
-      bind[ServiceLocator].to[ConductRServiceLocator].in[Singleton]
-    )
+    if(environment.mode == Mode.Prod)
+      Seq(bind[ServiceLocator].to[ConductRServiceLocator].in[Singleton])
+    else 
+      Seq.empty  
 }


### PR DESCRIPTION
Starts the `ConductRServiceLocator` for a Lagom project only in `Prod` mode. In `Dev` mode the embedded service locator from Lagom is always used. If the `ConductRServiceLocator` would be bound in `Dev` or `Test` mode as well then it leads to this exception in Lagom:

```
com.google.inject.CreationException: Unable to create injector, see the following errors:

1) A binding to com.lightbend.lagom.javadsl.api.ServiceLocator was already configured at com.typesafe.conductr.bundlelib.lagom.ServiceLocatorModule.bindings(ServiceLocatorModule.scala:16):
Binding(interface com.lightbend.lagom.javadsl.api.ServiceLocator to ConstructionTarget(class com.typesafe.conductr.bundlelib.lagom.ConductRServiceLocator) in interface javax.inject.Singleton) (via modules: com.google.inject.util.Modules$OverrideModule -> play.api.inject.guice.GuiceableModuleConversions$$anon$1).
  at com.lightbend.lagom.internal.registry.ServiceRegistryModule.configure(ServiceRegistryModule.scala:31) (via modules: com.google.inject.util.Modules$OverrideModule -> com.lightbend.lagom.internal.registry.ServiceRegistryModule)

1 error
    at com.google.inject.internal.Errors.throwCreationExceptionIfErrorsExist(Errors.java:466)
    at com.google.inject.internal.InternalInjectorCreator.initializeStatically(InternalInjectorCreator.java:155)
    at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:107)
    at com.google.inject.Guice.createInjector(Guice.java:96)
    at com.google.inject.Guice.createInjector(Guice.java:84)
    at play.api.inject.guice.GuiceBuilder.injector(GuiceInjectorBuilder.scala:181)
    at play.api.inject.guice.GuiceApplicationBuilder.build(GuiceApplicationBuilder.scala:123)
    at play.api.inject.guice.GuiceApplicationLoader.load(GuiceApplicationLoader.scala:21)
    at com.typesafe.conductr.bundlelib.lagom.ConductRApplicationLoader.load(ConductRApplicationLoader.scala:22)
    at play.core.server.LagomReloadableDevServerStart$$anonfun$mainDev$1$$anon$2$$anonfun$get$1$$anonfun$apply$1$$anonfun$2$$anonfun$3.apply(LagomReloadableDevServerStart.scala:151)
    at play.core.server.LagomReloadableDevServerStart$$anonfun$mainDev$1$$anon$2$$anonfun$get$1$$anonfun$apply$1$$anonfun$2$$anonfun$3.apply(LagomReloadableDevServerStart.scala:148)
    at play.utils.Threads$.withContextClassLoader(Threads.scala:21)
    at play.core.server.LagomReloadableDevServerStart$$anonfun$mainDev$1$$anon$2$$anonfun$get$1$$anonfun$apply$1$$anonfun$2.apply(LagomReloadableDevServerStart.scala:148)
    at play.core.server.LagomReloadableDevServerStart$$anonfun$mainDev$1$$anon$2$$anonfun$get$1$$anonfun$apply$1$$anonfun$2.apply(LagomReloadableDevServerStart.scala:124)
    at scala.Option.map(Option.scala:146)
    at play.core.server.LagomReloadableDevServerStart$$anonfun$mainDev$1$$anon$2$$anonfun$get$1$$anonfun$apply$1.apply(LagomReloadableDevServerStart.scala:124)
    at play.core.server.LagomReloadableDevServerStart$$anonfun$mainDev$1$$anon$2$$anonfun$get$1$$anonfun$apply$1.apply(LagomReloadableDevServerStart.scala:122)
    at scala.util.Success.flatMap(Try.scala:231)
    at play.core.server.LagomReloadableDevServerStart$$anonfun$mainDev$1$$anon$2$$anonfun$get$1.apply(LagomReloadableDevServerStart.scala:122)
    at play.core.server.LagomReloadableDevServerStart$$anonfun$mainDev$1$$anon$2$$anonfun$get$1.apply(LagomReloadableDevServerStart.scala:114)
    at scala.concurrent.impl.Future$PromiseCompletingRunnable.liftedTree1$1(Future.scala:24)
    at scala.concurrent.impl.Future$PromiseCompletingRunnable.run(Future.scala:24)
    at java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1402)
    at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
    at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
    at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
    at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)

Stacktrace caused by project observer-asp-impl (filesystem path to project is /Users/gaswamin/starbucks/Analytics/bits/lagom-asp/observer-asp-impl).
Hint: Maybe you have forgot to enable your service Module class via `play.modules.enabled`? (check in your project's application.conf)
```

Fixes https://github.com/lagom/lagom/issues/42