### PR TITLE
Run projects sequentially during tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ script:
 - jdk_switcher use oraclejdk7
 - sbt conductRBundleLib/test:test scalaConductRBundleLib/test:test akka23ConductRBundleLib/test:test play23ConductRBundleLib/test:test scalaConductRClientLib/test:test akka23ConductRClientLib/test:test play23ConductRClientLib/test:test
 - jdk_switcher use oraclejdk8
-- sbt conductRBundleLib/test:test scalaConductRBundleLib/test:test akka23ConductRBundleLib/test:test akka24ConductRBundleLib/test:test play23ConductRBundleLib/test:test play24ConductRBundleLib/test:test play25ConductRBundleLib/test:test scalaConductRClientLib/test:test akka23ConductRClientLib/test:test akka24ConductRClientLib/test:test play23ConductRClientLib/test:test play24ConductRClientLib/test:test play25ConductRClientLib/test:test javaConductRBundleLib/test:test lagom10ConductRBundleLib/test:test
+- sbt test

--- a/build.sbt
+++ b/build.sbt
@@ -25,6 +25,11 @@ lazy val root = project
     play25ConductRClientLib,
     lagom10ConductRBundleLib)
 
+// During testing run each project sequentially.
+// If the tests of each project run sequentially or in parallel
+// is defined in the `build.sbt` of the individual project itself
+concurrentRestrictions in Global += Tags.limit(Tags.Test, 1)    
+
 
 // Base
 lazy val common = project

--- a/common/build.sbt
+++ b/common/build.sbt
@@ -7,3 +7,5 @@ unmanagedSourceDirectories in Compile := List((javaSource in Compile).value)
 
 autoScalaLibrary := false
 crossPaths := false
+
+parallelExecution in Test := true

--- a/conductr-bundle-lib/build.sbt
+++ b/conductr-bundle-lib/build.sbt
@@ -7,3 +7,5 @@ unmanagedSourceDirectories in Compile := List((javaSource in Compile).value)
 
 autoScalaLibrary := false
 crossPaths := false
+
+parallelExecution in Test := true


### PR DESCRIPTION
By default `sbt test` is running all projects in parallel. This leads to problems because the conductr-client-lib projects needs to run sequentially.

This commits adds a falg in the global `build.sbt` to run the projects sequentially during testing. An alternative would be to use `sbt project1/test:test project2/test:test ...` instead of `sbt test`. However, `sbt release` is using the command `sbt test` on the root level before releasing a new version. So the latter wouldn't work when releasing new conductr-lib versions. Hence the fix.