### PR TITLE
Play: Set default port and ip

### DIFF
--- a/lagom10-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/lagom/ConductRApplicationLoader.scala
+++ b/lagom10-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/lagom/ConductRApplicationLoader.scala
@@ -7,7 +7,7 @@ import play.api.inject.guice.{ GuiceApplicationBuilder, GuiceApplicationLoader }
 import play.api.{ Application, ApplicationLoader, Configuration, Environment, Mode }
 
 /**
- * Including this class into a Play project will automatically set Play's
+ * Including this class into a Lagom project will automatically set Lagom's
  * configuration up from ConductR environment variables. Add the following
  * to your application.conf in order to include it:
  *

--- a/play23-conductr-bundle-lib/src/main/resources/reference-overrides.conf
+++ b/play23-conductr-bundle-lib/src/main/resources/reference-overrides.conf
@@ -8,9 +8,6 @@
 
 play {
 
-  # Custom ConductR Application loader to load ConductR related configurations
-  application.loader = "com.typesafe.conductr.bundlelib.play.api.ConductRApplicationLoader"
-
   server {
 
     # Use the ip address of the ConductR 'web' endpoint as the http address  

--- a/play23-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/Env.scala
+++ b/play23-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/Env.scala
@@ -13,14 +13,8 @@ object Env extends com.typesafe.conductr.bundlelib.scala.Env {
   /**
    * Provides various Play related properties.
    */
-  def asConfig: Config = {
-    val webName = sys.env.getOrElse("WEB_NAME", "WEB")
-
-    val httpAddress = sys.env.get(s"${webName}_BIND_IP").toList.map("http.address" -> _)
-    val httpPort = sys.env.get(s"${webName}_BIND_PORT").toList.map("http.port" -> _)
-
-    ConfigFactory.parseMap((httpAddress ++ httpPort ++ playActorSystem).toMap.asJava)
-  }
+  def asConfig: Config =
+    ConfigFactory.parseMap(playActorSystem.toMap.asJava)
 
   private def playActorSystem: List[(String, String)] =
     (for {

--- a/play23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/EnvSpecWithEnv.scala
+++ b/play23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/EnvSpecWithEnv.scala
@@ -8,8 +8,6 @@ class EnvSpecWithEnv extends AkkaUnitTest("EnvSpecWithEnvForHost") {
 
   "The Env functionality in the library" should {
     "initialize the env like expected" in {
-      config.getString("http.address") shouldBe "127.0.0.1"
-      config.getString("http.port") shouldBe "9023"
       config.getString("play.akka.actor-system") shouldBe "somesys-v1"
     }
   }

--- a/play24-conductr-bundle-lib/src/main/resources/play/reference-overrides.conf
+++ b/play24-conductr-bundle-lib/src/main/resources/play/reference-overrides.conf
@@ -6,6 +6,18 @@
 # from in ConductR's own reference.conf), but still allow users to override
 # ConductR's settings in their application.conf.
 
+play {
 
-# Custom ConductR Application loader to load ConductR related configurations
-play.application.loader = "com.typesafe.conductr.bundlelib.play.ConductRApplicationLoader"
+  # Custom ConductR Application loader to load ConductR related configurations
+  application.loader = "com.typesafe.conductr.bundlelib.play.ConductRApplicationLoader"
+
+  server {
+
+    # Use the ip address of the ConductR 'web' endpoint as the http address  
+    http.address=${?WEB_BIND_IP}
+
+    # Use the port of the ConductR 'web' endpoint as the http port
+    http.port=${?WEB_BIND_PORT}
+  }
+
+}  

--- a/play24-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/Env.scala
+++ b/play24-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/Env.scala
@@ -13,14 +13,8 @@ object Env extends com.typesafe.conductr.bundlelib.scala.Env {
   /**
    * Provides various Play related properties.
    */
-  def asConfig: Config = {
-    val webName = sys.env.getOrElse("WEB_NAME", "WEB")
-
-    val httpAddress = sys.env.get(s"${webName}_BIND_IP").toList.map("http.address" -> _)
-    val httpPort = sys.env.get(s"${webName}_BIND_PORT").toList.map("http.port" -> _)
-
-    ConfigFactory.parseMap((httpAddress ++ httpPort ++ playActorSystem).toMap.asJava)
-  }
+  def asConfig: Config =
+    ConfigFactory.parseMap(playActorSystem.toMap.asJava)
 
   private def playActorSystem: List[(String, String)] =
     (for {

--- a/play24-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/EnvSpecWithEnv.scala
+++ b/play24-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/EnvSpecWithEnv.scala
@@ -8,8 +8,6 @@ class EnvSpecWithEnv extends AkkaUnitTest("EnvSpecWithEnvForHost") {
 
   "The Env functionality in the library" should {
     "initialize the env like expected" in {
-      config.getString("http.address") shouldBe "127.0.0.1"
-      config.getString("http.port") shouldBe "9024"
       config.getString("play.akka.actor-system") shouldBe "somesys-v1"
     }
   }

--- a/play25-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/api/Env.scala
+++ b/play25-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/api/Env.scala
@@ -13,14 +13,8 @@ object Env extends com.typesafe.conductr.bundlelib.scala.Env {
   /**
    * Provides various Play related properties.
    */
-  def asConfig: Config = {
-    val webName = sys.env.getOrElse("WEB_NAME", "WEB")
-
-    val httpAddress = sys.env.get(s"${webName}_BIND_IP").toList.map("http.address" -> _)
-    val httpPort = sys.env.get(s"${webName}_BIND_PORT").toList.map("http.port" -> _)
-
-    ConfigFactory.parseMap((httpAddress ++ httpPort ++ playActorSystem).toMap.asJava)
-  }
+  def asConfig: Config =
+    ConfigFactory.parseMap(playActorSystem.toMap.asJava)
 
   private def playActorSystem: List[(String, String)] =
     (for {

--- a/play25-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/api/EnvSpecWithEnv.scala
+++ b/play25-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/api/EnvSpecWithEnv.scala
@@ -8,8 +8,6 @@ class EnvSpecWithEnv extends AkkaUnitTest("EnvSpecWithEnvForHost") {
 
   "The Env functionality in the library" should {
     "initialize the env like expected" in {
-      config.getString("http.address") shouldBe "127.0.0.1"
-      config.getString("http.port") shouldBe "9025"
       config.getString("play.akka.actor-system") shouldBe "somesys-v1"
     }
   }


### PR DESCRIPTION
For a Play project it is currently necessary to overwrite the `http.port` and `http.address` envs with the `startCommand` option in the `build.sbt` of the user project.

**Example**

```
BundleKeys.startCommand ++= Seq(
  "-Dhttp.address=$WEB_BIND_IP",
  "-Dhttp.port=$WEB_BIND_PORT"
)
```

In `conductr-bundle-lib` the current approach to automate setting these envs is by adding configuration to the Play application loader: https://github.com/typesafehub/conductr-lib/blob/master/play25-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/api/Env.scala#L19-L20

Unfortunately, this approach doesn't work. Reason is that these envs are not used by Play when the netty server gets started. So Play will start itself inside of ConductR still on `0.0.0.0:9000`. Instead it is necessary to override `play.server.http.port` and `play.server.http.address` in the `overrides-referece.conf`.

To keep things simple we override the port and address with the `default` endpoints (formerly `web`) instead of using the project name as a key. Otherwise it would be hard to resolve the particular name of the project inside the configuration file.

This PR has been tested with reactive-maps and chirper. I could see that the ip and port of the netty server is allocated properly. However, some other things were still not working (yet) with sbt-conductr 2.0.0. This PR is therefore still on `WIP` because I am not sure yet if this PR introduced this issues.