### PR TITLE
Publicise createLookupPayload

### DIFF
--- a/conductr-bundle-lib/src/main/java/com/typesafe/conductr/bundlelib/LocationService.java
+++ b/conductr-bundle-lib/src/main/java/com/typesafe/conductr/bundlelib/LocationService.java
@@ -35,6 +35,27 @@ public class LocationService {
     }
 
     /**
+     * Create the HttpPayload necessary to look up a service by name, along with an explicit service locator address.
+     *
+     * If the service is available and can be looked up the response for the HTTP request should be
+     * 307 (Temporary Redirect), and the resulting URI to the service is in the "Location" header of the response.
+     * A Cache-Control header may also be returned indicating the maxAge that the location should be cached for.
+     * If the service can not be looked up the response should be 404 (Not Found).
+     * All other response codes are considered illegal.
+     *
+     * @param serviceLocator The http address of the service locator e.g. http://10.0.2.3:4444
+     * @param serviceName The name of the service
+     * @return An HttpPayload describing how to do the service lookup or null if
+     * this program is not running within ConductR
+     * @throws MalformedURLException
+     */
+    public static HttpPayload createLookupPayload(String serviceLocator, String serviceName) throws MalformedURLException {
+        String serviceNameWithLeadingSlash = serviceName.startsWith("/") ? serviceName : "/" + serviceName;
+        URL locatorUrl = new URL(serviceLocator + serviceNameWithLeadingSlash);
+        return new HttpPayload(locatorUrl);
+    }
+
+    /**
      * A convenience function where the payload url is created when this bundle component
      * is running in the context of ConductR. If it is not then a fallback is returned.
      * @param serviceName The name of the service
@@ -48,11 +69,5 @@ public class LocationService {
         } else {
             return payload.getUrl();
         }
-    }
-
-    static HttpPayload createLookupPayload(String serviceLocator, String serviceName) throws MalformedURLException {
-        String serviceNameWithLeadingSlash = serviceName.startsWith("/") ? serviceName : "/" + serviceName;
-        URL locatorUrl = new URL(serviceLocator + serviceNameWithLeadingSlash);
-        return new HttpPayload(locatorUrl);
     }
 }


### PR DESCRIPTION
Expose the previously private `createLookupPayload` so that consumers are able to supply an alternate address of the service locator.