### PR TITLE
Set the location cache reaper timers as daemon threads

### DIFF
--- a/java-conductr-bundle-lib/src/main/java/com/typesafe/conductr/bundlelib/java/LocationCache.java
+++ b/java-conductr-bundle-lib/src/main/java/com/typesafe/conductr/bundlelib/java/LocationCache.java
@@ -20,7 +20,7 @@ public class LocationCache implements CacheLike {
 
     private final ConcurrentMap<String, CompletionStage<Optional<Tuple<URI, Optional<Duration>>>>> cache = new ConcurrentHashMap<>();
 
-    private final Timer reaperTimer = new Timer();
+    private final Timer reaperTimer = new Timer("LocationCache-Reaper", true /* daemon thread */);
 
     @Override
     public CompletionStage<Optional<URI>> getOrElseUpdate(String serviceName, Supplier<CompletionStage<Optional<Tuple<URI, Optional<Duration>>>>> op) {

--- a/scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/scala/LocationCache.scala
+++ b/scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/scala/LocationCache.scala
@@ -36,7 +36,7 @@ class LocationCache extends CacheLike {
 
   private val cache = TrieMap.empty[String, Future[Option[(JavaURI, Option[FiniteDuration])]]]
 
-  val reaperTimer = new Timer()
+  val reaperTimer = new Timer("LocationCache-Reaper", true /* daemon thread */ )
 
   override def getOrElseUpdate(serviceName: String)(op: => Future[Option[(JavaURI, Option[FiniteDuration])]]): Future[Option[JavaURI]] = {
     import Implicits.global


### PR DESCRIPTION
So that these threads don't prevent the JVM from shutting down when the main thread or actor systems are finished.