### PR TITLE
Implement conduct load with stream-based approach

### DIFF
--- a/akka23-conductr-client-lib/src/test/scala/com/typesafe/conductr/clientlib/akka/ControlClientSpec.scala
+++ b/akka23-conductr-client-lib/src/test/scala/com/typesafe/conductr/clientlib/akka/ControlClientSpec.scala
@@ -11,6 +11,7 @@ import akka.http.scaladsl.model.HttpEntity.IndefiniteLength
 import akka.http.scaladsl.server.Directives
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.stream.ActorMaterializer
 import akka.stream.actor.ActorPublisher
 import akka.stream.scaladsl.{ FileIO, Flow, Keep, Sink, Source }
@@ -25,7 +26,7 @@ import de.heikoseeberger.akkasse.{ EventStreamMarshalling, ServerSentEvent }
 import org.reactivestreams.Publisher
 import org.scalatest.Inside
 import scala.concurrent.duration._
-import scala.concurrent.{ Future, Await }
+import scala.concurrent.{ ExecutionContext, Future, Await }
 import akka.http.scaladsl.model._
 import scala.util.{ Failure, Success }
 
@@ -41,6 +42,25 @@ object ControlClientSpec {
       Source.fromPublisher(pub).map(new String(_)).runFold("")(_ + _),
       timeout.duration
     )
+
+  def extractFromBodyPart(bodyPart: Multipart.FormData.BodyPart)(implicit mat: ActorMaterializer, ec: ExecutionContext): (String, String) = {
+    bodyPart.entity.dataBytes.runWith(Sink.ignore)
+    val name = bodyPart.name
+    val fileName = bodyPart.contentDispositionHeader.flatMap(_.params.get("filename")).getOrElse("n/a")
+    (name, fileName)
+  }
+
+  def extractFromMultipartForm(formData: Multipart.FormData, expectedLength: Int)(implicit mat: ActorMaterializer, ec: ExecutionContext): Future[Seq[(String, String)]] =
+    for {
+      parts <- formData.parts.prefixAndTail(expectedLength).runWith(Sink.head)
+    } yield {
+      val (expectedParts, _) = parts
+      expectedParts.map(extractFromBodyPart)
+    }
+
+  def toByteArrayPublisher(input: String)(implicit mat: ActorMaterializer): Publisher[Array[Byte]] =
+    Source.single(input).map(_.getBytes).runWith(Sink.asPublisher(fanout = false))
+
 }
 
 class ControlClientSpec extends AkkaUnitTestWithFixture("ControlClientSpec") with Inside {
@@ -54,7 +74,7 @@ class ControlClientSpec extends AkkaUnitTestWithFixture("ControlClientSpec") wit
 
   def systemFixture(f: this.FixtureParam) = new {
     implicit val system = f.system
-    implicit val cc = ConnectionContext()
+    implicit val cc: ConnectionContext = ConnectionContext()
     implicit val mat = cc.actorMaterializer
     implicit val ec = cc.actorMaterializer.executionContext
     implicit val timeout = f.timeout
@@ -264,19 +284,29 @@ class ControlClientSpec extends AkkaUnitTestWithFixture("ControlClientSpec") wit
       val sys = systemFixture(f)
       import sys._
 
+      val bodyPartsMonitor = TestProbe()
+
       // format: OFF
       val route =
         pathPrefix(ApiVersion / "bundles") {
           post {
-            complete {
-              HttpResponse(entity = HttpEntity(ContentTypes.`application/json`,
-                s"""
-                   |{
-                   |  "requestId": "$RequestId",
-                   |  "bundleId": "${BundleFrontend.bundleId}"
-                   |}
-                """.stripMargin)
-              )
+            extractRequest { request =>
+              complete {
+                for {
+                  formData <- Unmarshal(request.entity).to[Multipart.FormData]
+                  expectedBodyParts <- ControlClientSpec.extractFromMultipartForm(formData, expectedLength = 2)
+                } yield {
+                  bodyPartsMonitor.ref ! expectedBodyParts
+                  HttpResponse(entity = HttpEntity(ContentTypes.`application/json`,
+                    s"""
+                       |{
+                       |  "requestId": "$RequestId",
+                       |  "bundleId": "${BundleFrontend.bundleId}"
+                       |}
+                    """.stripMargin)
+                  )
+                }
+              }
             }
           }
         }
@@ -284,7 +314,63 @@ class ControlClientSpec extends AkkaUnitTestWithFixture("ControlClientSpec") wit
 
       withServer(route) {
         val request = ControlClient(HostUrl).loadBundle(BundleUri, None)
-        Await.result(request, timeout.duration) shouldBe BundleRequestSuccess(RequestId, BundleFrontend.bundleId)
+        Await.result(request, timeout.duration * 2) shouldBe BundleRequestSuccess(RequestId, BundleFrontend.bundleId)
+
+        bodyPartsMonitor.expectMsg(Seq(
+          ("bundleConf", "bundle.conf"),
+          ("bundle", BundleFileName)
+        ))
+
+      }
+    }
+
+    "load a valid bundle + config overlay + configuration" in { f =>
+      val sys = systemFixture(f)
+      import sys._
+
+      val bodyPartsMonitor = TestProbe()
+
+      // format: OFF
+      val route =
+        pathPrefix(ApiVersion / "bundles") {
+          post {
+            extractRequest { request =>
+              complete {
+              for {
+                formData <- Unmarshal(request.entity).to[Multipart.FormData]
+                expectedBodyParts <- ControlClientSpec.extractFromMultipartForm(formData, expectedLength = 4)
+              } yield {
+                bodyPartsMonitor.ref ! expectedBodyParts
+                HttpResponse(entity = HttpEntity(ContentTypes.`application/json`,
+                  s"""
+                     |{
+                     |  "requestId": "$RequestId",
+                     |  "bundleId": "${BundleFrontend.bundleId}"
+                     |}
+                  """.stripMargin)
+                )
+              }
+            }
+            }
+          }
+        }
+      // format: ON
+
+      withServer(route) {
+        val request = ControlClient(HostUrl).loadBundle(
+          bundleConf = ControlClientSpec.toByteArrayPublisher("bundle.conf"),
+          bundleConfOverlay = Some(ControlClientSpec.toByteArrayPublisher("bundle.conf overlay")),
+          bundle = BundleFile("bundle-1.zip", ControlClientSpec.toByteArrayPublisher("bundle zip file")),
+          config = Some(BundleConfigurationFile("config-1.zip", ControlClientSpec.toByteArrayPublisher("config zip file")))
+        )
+        Await.result(request, timeout.duration * 2) shouldBe BundleRequestSuccess(RequestId, BundleFrontend.bundleId)
+
+        bodyPartsMonitor.expectMsg(Seq(
+          ("bundleConf", "bundle.conf"),
+          ("bundleConfOverlay", "bundle.conf"),
+          ("bundle", "bundle-1.zip"),
+          ("configuration", "config-1.zip")
+        ))
       }
     }
 

--- a/akka23-conductr-client-lib/src/test/scala/com/typesafe/conductr/clientlib/akka/TestData.scala
+++ b/akka23-conductr-client-lib/src/test/scala/com/typesafe/conductr/clientlib/akka/TestData.scala
@@ -15,8 +15,8 @@ object TestData {
 
   val RequestId = UUID.randomUUID()
 
-  val BundleFile = "typesafe-conductr-tester-v0-5dd6695ed93ea6f10d856a97e2e90b56eb28bdc7d98555be944066b83f536a55.zip"
-  val BundleUri = TestData.getClass.getClassLoader.getResource(BundleFile).toURI
+  val BundleFileName = "typesafe-conductr-tester-v0-5dd6695ed93ea6f10d856a97e2e90b56eb28bdc7d98555be944066b83f536a55.zip"
+  val BundleUri = TestData.getClass.getClassLoader.getResource(BundleFileName).toURI
 
   val BundleSystem = "some-system"
   val BundleSystemVersion = "1.0.0"

--- a/akka24-conductr-client-lib/src/main/scala/com/typesafe/conductr/clientlib/akka/ControlClient.scala
+++ b/akka24-conductr-client-lib/src/main/scala/com/typesafe/conductr/clientlib/akka/ControlClient.scala
@@ -2,21 +2,20 @@ package com.typesafe.conductr.clientlib.akka
 
 import java.io._
 import java.net.{ URI, URL }
-import java.nio.file.{ Paths, Path }
+import java.nio.file.Paths
 import java.util.zip.ZipInputStream
 
 import akka.http.scaladsl.marshalling.Marshal
 import akka.http.scaladsl.model.HttpEntity.IndefiniteLength
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.unmarshalling.{ PredefinedFromEntityUnmarshallers, Unmarshal }
-import akka.stream.IOResult
-import akka.stream.scaladsl.{ FileIO, Sink, Source, StreamConverters }
+import akka.stream.scaladsl.{ FileIO, Sink, Source }
 import akka.util.ByteString
 import com.typesafe.conductr.lib.HttpPayload
 import com.typesafe.conductr.lib.akka.{ ConnectionContext, ConnectionHandler }
 import com.typesafe.conductr.clientlib.akka.models._
 import com.typesafe.conductr.clientlib.scala.models._
-import com.typesafe.conductr.clientlib.scala.{ HttpStatusCodes, AbstractControlClient, withCloseable, withZipInputStream }
+import com.typesafe.conductr.clientlib.scala.{ AbstractControlClient, withCloseable, withZipInputStream }
 import de.heikoseeberger.akkasse.{ EventStreamUnmarshalling, ServerSentEvent }
 import org.reactivestreams.Publisher
 import play.api.libs.json.{ Json, Reads }
@@ -80,9 +79,6 @@ class ControlClient(handler: ConnectionHandler, conductrAddress: URL, apiVersion
       import cc.actorMaterializer.executionContext
 
       def bundleGet: Future[BundleGetResult] = {
-
-        def toByteArrayPublisher(input: Source[ByteString, _]): Publisher[Array[Byte]] =
-          input.map(_.toArray).runWith(Sink.asPublisher(fanout = false))
 
         def bundleFileFromResponse(bundleParts: Seq[(String, String, Multipart.FormData.BodyPart)]): BundleFile =
           bundleParts match {
@@ -157,26 +153,61 @@ class ControlClient(handler: ConnectionHandler, conductrAddress: URL, apiVersion
    *         - BundleRequestFailure if the loading request has been failed. This object contains the HTTP status code and error message.
    */
   override def loadBundle(bundle: URI, config: Option[URI] = None)(implicit cc: ConnectionContext): Future[BundleRequestResult] = {
-    def createRequestBody: Future[RequestEntity] = {
-      import cc.actorMaterializer.executionContext
+    def filename(uri: URI): String =
+      Paths.get(uri.getPath).getFileName.toString
 
-      def fileBodyPart(name: String, filename: String, source: Source[ByteString, Future[IOResult]]): Multipart.FormData.BodyPart =
+    def filePublisher(uri: URI): Publisher[Array[Byte]] =
+      toByteArrayPublisher(FileIO.fromPath(Paths.get(uri.getPath)))
+
+    val tmpDir = new File(System.getProperty("java.io.tmpdir"))
+
+    val bundleConf = extractZipEntry("bundle.conf", bundle, tmpDir).get
+    val bundleConfOverlay = config.flatMap(extractZipEntry("bundle.conf", _, tmpDir))
+
+    val bundleConfData = filePublisher(bundleConf)
+    val bundleConfOverlayData = bundleConfOverlay.map(filePublisher)
+    val bundleData = BundleFile(filename(bundle), filePublisher(bundle))
+    val configData = config.map(v => BundleConfigurationFile(filename(v), filePublisher(v)))
+
+    loadBundle(bundleConfData, bundleConfOverlayData, bundleData, configData)
+  }
+
+  /**
+   * @see [[AbstractControlClient.loadBundle()]]
+   * @param bundleConf bundle.conf contained within the `bundle` file.
+   * @param bundleConfOverlay bundle.conf override contained within the `config` file.
+   * @param bundle The file that is the bundle.
+   *               The filename is important with its hex digest string and is required to be consistent
+   *               with the SHA-256 hash of the bundle’s contents.
+   *               Any inconsistency between the hashes will result in the load being rejected.
+   * @param config Similar in form to the bundle, only that is the file that describes the configuration.
+   *               Again any inconsistency between the hex digest string in the filename, and the SHA-256 digest
+   *               of the actual contents will result in the load being rejected.
+   * @param cc implicit connection context
+   * @return The result as a Future[BundleRequestResult]. BundleRequestResult is a sealed trait and can be either:
+   *         - BundleRequestSuccess if the loading request has been succeeded. This object contains the request and bundle id
+   *         - BundleRequestFailure if the loading request has been failed. This object contains the HTTP status code and error message.
+   */
+  override def loadBundle(bundleConf: Publisher[Array[Byte]], bundleConfOverlay: Option[Publisher[Array[Byte]]], bundle: BundleFile, config: Option[BundleConfigurationFile])(implicit cc: ConnectionContext): Future[BundleRequestResult] = {
+    import cc.actorMaterializer
+    import cc.context.dispatcher
+
+    def createRequestBody: Future[RequestEntity] = {
+
+      def fileBodyPart(name: String, filename: String, source: Source[ByteString, _]): Multipart.FormData.BodyPart =
         Multipart.FormData.BodyPart(
           name,
           IndefiniteLength(MediaTypes.`application/octet-stream`, source),
           Map("filename" -> filename)
         )
 
-      def publisher(uri: URI): Source[ByteString, Future[IOResult]] =
-        StreamConverters.fromInputStream(() => new URL(absolute(uri).toString).openStream())
+      def toByteStringSource(input: Publisher[Array[Byte]]): Source[ByteString, _] =
+        Source.fromPublisher(input).map(ByteString(_))
 
-      val tmpDir = new File(System.getProperty("java.io.tmpdir"))
-      val bundleConf = extractZipEntry("bundle.conf", bundle, tmpDir).get
-      val bundleConfBodyPart = fileBodyPart("bundleConf", filename(bundleConf.toString), publisher(bundleConf))
-      val bundleConfOverlay = config.flatMap(extractZipEntry("bundle.conf", _, tmpDir))
-      val bundleConfOverlayBodyPart = bundleConfOverlay.map(overlay => fileBodyPart("bundleConfOverlay", filename(overlay.toString), publisher(overlay)))
-      val bundleFileBodyPart = fileBodyPart("bundle", filename(bundle.toString), publisher(bundle))
-      val configFileBodyPart = config.map(c => fileBodyPart("configuration", filename(c.toString), publisher(c)))
+      val bundleConfBodyPart = fileBodyPart("bundleConf", "bundle.conf", toByteStringSource(bundleConf))
+      val bundleConfOverlayBodyPart = bundleConfOverlay.map(overlay => fileBodyPart("bundleConfOverlay", "bundle.conf", toByteStringSource(overlay)))
+      val bundleFileBodyPart = fileBodyPart("bundle", bundle.fileName, toByteStringSource(bundle.data))
+      val configFileBodyPart = config.map(c => fileBodyPart("configuration", c.fileName, toByteStringSource(c.data)))
 
       val bodyParts = List(Some(bundleConfBodyPart), bundleConfOverlayBodyPart, Some(bundleFileBodyPart), configFileBodyPart).flatten
       val result = Marshal(Multipart.FormData(Source(bodyParts))).to[RequestEntity]
@@ -420,6 +451,11 @@ class ControlClient(handler: ConnectionHandler, conductrAddress: URL, apiVersion
 
   private def filename(path: String): String =
     path.split('/').lastOption.getOrElse("")
+
+  private def toByteArrayPublisher(input: Source[ByteString, _])(implicit cc: ConnectionContext): Publisher[Array[Byte]] = {
+    import cc.actorMaterializer
+    input.map(_.toArray).runWith(Sink.asPublisher(fanout = false))
+  }
 
   // TODO: Use Akka stream to extract and read the zip file.
   //       In the current Akka streams version 2.0.1 there is no utility to extract a zip file and iterate over

--- a/akka24-conductr-client-lib/src/test/scala/com/typesafe/conductr/clientlib/akka/TestData.scala
+++ b/akka24-conductr-client-lib/src/test/scala/com/typesafe/conductr/clientlib/akka/TestData.scala
@@ -15,8 +15,8 @@ object TestData {
 
   val RequestId = UUID.randomUUID()
 
-  val BundleFile = "typesafe-conductr-tester-v0-5dd6695ed93ea6f10d856a97e2e90b56eb28bdc7d98555be944066b83f536a55.zip"
-  val BundleUri = TestData.getClass.getClassLoader.getResource(BundleFile).toURI
+  val BundleFileName = "typesafe-conductr-tester-v0-5dd6695ed93ea6f10d856a97e2e90b56eb28bdc7d98555be944066b83f536a55.zip"
+  val BundleUri = TestData.getClass.getClassLoader.getResource(BundleFileName).toURI
 
   val BundleSystem = "some-system"
   val BundleSystemVersion = "1.0.0"


### PR DESCRIPTION
Also deprecate existing conduct load which takes file-based URI as input argument.

Increase coverage for the conduct load test by asserting expected body parts in the received HTTP request.