### PR TITLE
Introduce Unmarshalling for Bundle Endpoints declared with Request ACLs

### DIFF
--- a/akka24-conductr-client-lib/src/test/scala/com/typesafe/conductr/clientlib/akka/BundlesConnectorSpec.scala
+++ b/akka24-conductr-client-lib/src/test/scala/com/typesafe/conductr/clientlib/akka/BundlesConnectorSpec.scala
@@ -1,0 +1,151 @@
+package com.typesafe.conductr.clientlib.akka
+
+import java.net.URL
+
+import akka.actor.ActorRef
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.marshalling.Marshal
+import akka.http.scaladsl.model.{ ContentTypes, HttpEntity, HttpResponse }
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.client.RequestBuilding._
+import akka.pattern._
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{ Sink, Source }
+import akka.testkit.TestActor.AutoPilot
+import akka.testkit.{ TestActor, TestProbe }
+import com.typesafe.conductr.clientlib.akka.TestData._
+import com.typesafe.conductr.lib.AkkaUnitTest
+import de.heikoseeberger.akkasse.{ ServerSentEvent, EventStreamMarshalling }
+import scala.concurrent.duration._
+import scala.collection.immutable._
+
+import scala.concurrent.Await
+
+class BundlesConnectorSpec extends AkkaUnitTest {
+  "should emit bundles retrieved on the initial connection and subsequent bundle changes" in {
+    val f = testFixture("127.0.0.1", 6667)
+    import f._
+
+    val bundleStreamMonitor = TestProbe()
+
+    Source.single(Get("/v2/bundles/events") -> Get("/v2/bundles"))
+      .via(BundlesConnector.connect(serverAddress))
+      .runForeach(bundleStreamMonitor.ref ! _)
+
+    // Initial bundle state should be emitted
+    getBundles.expectMsg(ControlClientSpec.GetBundles)
+    getBundles.reply(s"[${TestData.BundleBackendAsJson}]")
+
+    bundleStreamMonitor.expectMsg(Seq(TestData.BundleBackend))
+
+    // Bundle Events should be requested
+    getBundleEvents.expectMsg(ControlClientSpec.GetBundleEvents)
+    getBundleEvents.reply(
+      Source.tick(
+        initialDelay = 100.millis,
+        interval = 800.millis,
+        tick = Seq(
+          ServerSentEvent(s"${BundleFrontend.bundleId}", "bundleInstallationAdded"),
+          ServerSentEvent.heartbeat,
+          ServerSentEvent.heartbeat,
+          ServerSentEvent.heartbeat,
+          ServerSentEvent.heartbeat
+        )
+      ).mapConcat(identity)
+    )
+
+    // Simulate no changes within bundle state
+    getBundles.expectMsg(ControlClientSpec.GetBundles)
+    getBundles.reply(s"[${TestData.BundleBackendAsJson}]")
+
+    bundleStreamMonitor.expectNoMsg(500.millis)
+
+    // Simulate changes within bundle state
+    getBundles.expectMsg(ControlClientSpec.GetBundles)
+    getBundles.reply(s"[${TestData.BundleBackendAsJson}, ${TestData.BundleFrontendAsJson}]")
+
+    bundleStreamMonitor.expectMsg(Seq(TestData.BundleBackend, TestData.BundleFrontend))
+
+    // Simulate no changes within bundle state
+    getBundles.expectMsg(ControlClientSpec.GetBundles)
+    getBundles.reply(s"[${TestData.BundleBackendAsJson}, ${TestData.BundleFrontendAsJson}]")
+
+    bundleStreamMonitor.expectNoMsg(500.millis)
+  }
+
+  "should fail with timeout error if source does not complete within specified timeout" in {
+    val f = testFixture("127.0.0.1", 6668)
+    import f._
+
+    getBundles.setAutoPilot(new TestActor.AutoPilot {
+      override def run(sender: ActorRef, msg: Any): AutoPilot = {
+        msg shouldBe ControlClientSpec.GetBundles
+        sender ! "[]"
+        keepRunning
+      }
+    })
+
+    val result = Source.single(Get("/v2/bundles/events") -> Get("/v2/bundles"))
+      .via(BundlesConnector.connect(serverAddress, stopAfter = Some(timeout.duration / 2)))
+      .runWith(Sink.ignore)
+
+    // Bundle Events should be requested
+    getBundleEvents.expectMsg(ControlClientSpec.GetBundleEvents)
+    getBundleEvents.reply(
+      Source.tick(
+        initialDelay = 100.millis,
+        interval = 800.millis,
+        tick = Seq(
+          ServerSentEvent(s"${BundleFrontend.bundleId}", "bundleInstallationAdded"),
+          ServerSentEvent.heartbeat,
+          ServerSentEvent.heartbeat,
+          ServerSentEvent.heartbeat,
+          ServerSentEvent.heartbeat
+        )
+      ).mapConcat(identity)
+    )
+
+    val error = intercept[RuntimeException] {
+      Await.result(result, timeout.duration)
+    }
+    error shouldBe BundlesConnector.TimeoutException
+  }
+
+  def testFixture(serverHost: String, serverPort: Int) = new {
+    implicit val dispatcher = system.dispatcher
+    implicit val materializer = ActorMaterializer()
+
+    val getBundleEvents = TestProbe()
+    val getBundles = TestProbe()
+
+    // format: OFF
+    val route = pathPrefix("v2" / "bundles") {
+      path("events") {
+        get {
+          complete {
+            import EventStreamMarshalling._
+            getBundleEvents.ref.ask(ControlClientSpec.GetBundleEvents)
+              .mapTo[Source[ServerSentEvent, _]]
+              .map(Marshal(_).to[HttpResponse])
+          }
+        }
+      } ~
+      get {
+        complete {
+          getBundles.ref.ask(ControlClientSpec.GetBundles)
+            .mapTo[String]
+            .map { json =>
+              HttpResponse(entity = HttpEntity(ContentTypes.`application/json`, json))
+            }
+        }
+      }
+    }
+    // format: ON
+
+    val serverAddress = new URL(s"http://$serverHost:$serverPort")
+    Await.ready(
+      Http().bindAndHandle(route, serverHost, serverPort),
+      timeout.duration
+    )
+  }
+}

--- a/akka24-conductr-client-lib/src/test/scala/com/typesafe/conductr/clientlib/akka/JsonMarshallingSpec.scala
+++ b/akka24-conductr-client-lib/src/test/scala/com/typesafe/conductr/clientlib/akka/JsonMarshallingSpec.scala
@@ -1,0 +1,17 @@
+package com.typesafe.conductr.clientlib.akka
+
+import com.typesafe.conductr.clientlib.scala.models.Bundle
+import com.typesafe.conductr.lib.UnitTest
+import play.api.libs.json.Json
+
+class JsonMarshallingSpec extends UnitTest {
+  "unmarshalling bundle" should {
+    "result in correct json when bundle is declared with endpoints having service URI and request ACLs" in {
+      import JsonMarshalling._
+      import TestData._
+
+      val result = Json.parse(BundleWithServicesAndRequestAclJson).as[Bundle]
+      result shouldBe BundleWithServicesAndRequestAcl
+    }
+  }
+}

--- a/scala-conductr-client-lib/src/main/scala/com/typesafe/conductr/clientlib/scala/AbstractControlClient.scala
+++ b/scala-conductr-client-lib/src/main/scala/com/typesafe/conductr/clientlib/scala/AbstractControlClient.scala
@@ -66,16 +66,12 @@ abstract class AbstractControlClient(conductrAddress: URL) {
    * @param affinity Optional: Identifier to other bundle.
    *                 If specified, the current bundle will be run on the same host where
    *                 the specified bundle is currently running.
-   * @param completeWhenScaleAchieved if set to true, then the future returned will be completed when bundle to be scaled reaches the
-   *                     number of requested instances.
-   *                     This is done by subscribing to bundle events SSE, and checking for number of running bundles
-   *                     whenever there are changes in the bundle events.
    * @param cc implicit connection context
    * @return The result as a Future[BundleRequestResult]. BundleRequestResult is a sealed trait and can be either:
    *         - BundleRequestSuccess if the scaling request has been succeeded. This object contains the request and bundle id
    *         - BundleRequestFailure if the scaling request has been failed. This object contains the HTTP status code and error message.
    */
-  def runBundleComplete(bundleId: BundleId, scale: Option[Int] = None, affinity: Option[String] = None, completeWhenScaleAchieved: Boolean = true, completeTimeout: FiniteDuration = 30.seconds)(implicit cc: CC): Future[BundleRequestResult]
+  def runBundleComplete(bundleId: BundleId, scale: Option[Int] = None, affinity: Option[String] = None, completeTimeout: FiniteDuration = 30.seconds)(implicit cc: CC): Future[BundleRequestResult]
 
   /**
    * Stop a running bundle. Requests for already stopped bundles will be send to the ConductR control server as well.
@@ -138,15 +134,12 @@ abstract class AbstractControlClient(conductrAddress: URL) {
    * @param config Optional: Similar in form to the bundle, only that is the file that describes the configuration.
    *               Again any inconsistency between the hex digest string in the filename, and the SHA-256 digest
    *               of the actual contents will result in the load being rejected.
-   * @param completeWhenInstalled if set to true, then the future returned will be completed when bundle is installed.
-   *                       This is done by subscribing to bundle events SSE, and checking for bundle installation
-   *                       whenever there are changes in the bundle events.
    * @param cc implicit connection context
    * @return The result as a Future[BundleRequestResult]. BundleRequestResult is a sealed trait and can be either:
    *         - BundleRequestSuccess if the loading request has been succeeded. This object contains the request and bundle id
    *         - BundleRequestFailure if the loading request has been failed. This object contains the HTTP status code and error message.
    */
-  def loadBundleComplete(bundleConf: Publisher[Array[Byte]], bundleConfOverlay: Option[Publisher[Array[Byte]]], bundle: BundleFile, config: Option[BundleConfigurationFile], completeWhenInstalled: Boolean = true, completeTimeout: FiniteDuration = 30.seconds)(implicit cc: CC): Future[BundleRequestResult]
+  def loadBundleComplete(bundleConf: Publisher[Array[Byte]], bundleConfOverlay: Option[Publisher[Array[Byte]]], bundle: BundleFile, config: Option[BundleConfigurationFile], completeTimeout: FiniteDuration = 30.seconds)(implicit cc: CC): Future[BundleRequestResult]
   /**
    * Unload a bundle from all ConductR instances.
    *

--- a/scala-conductr-client-lib/src/main/scala/com/typesafe/conductr/clientlib/scala/models/BundleConfig.scala
+++ b/scala-conductr-client-lib/src/main/scala/com/typesafe/conductr/clientlib/scala/models/BundleConfig.scala
@@ -5,6 +5,26 @@ import java.net.URI
 // Instead of using the name 'BundleConfigEndpoint' we should create the case class 'Endpoint'
 // inside the companion object 'BundleConfig' to access it with 'BundleConfig.Endpoint'.
 // However, when using 'BundleConfig.Endpoint' the Json.format in 'JsonMarshalling' doesn't work anymore!
-final case class BundleConfigEndpoint(bindProtocol: String, serviceName: Option[String], services: Set[URI])
+/**
+ * Represents configuration for a particular endpoint.
+ *
+ * @param bindProtocol the protocol which the endpoint binds to. Valid values are `http`, `tcp`, or `udp`.
+ *                     Proxying only works for `http` and `tcp` based endpoints.
+ * @param serviceName optional. If specified, the endpoint can be looked up through service locator through
+ *                    [[serviceName]].
+ * @param services deprecated. List of services for a given endpoint. Deprecated in lieu of declaration using
+ *                 [[requestAcls]].
+ * @param requestAcls One or more request mappings to access the declared endpoint.
+ */
+final case class BundleConfigEndpoint(
+  bindProtocol: String,
+  serviceName: Option[String],
+  @deprecated("Deprecated in lieu of Request ACL endpoint declaration", since = "ConductR 2.0") services: Set[URI],
+  requestAcls: Seq[RequestAcl]
+)
 
+/**
+ * Represents endpoint configurations for a given [[Bundle]].
+ * @param endpoints Endpoints configuration
+ */
 final case class BundleConfig(endpoints: Map[String, BundleConfigEndpoint])

--- a/scala-conductr-client-lib/src/main/scala/com/typesafe/conductr/clientlib/scala/models/RequestAcl.scala
+++ b/scala-conductr-client-lib/src/main/scala/com/typesafe/conductr/clientlib/scala/models/RequestAcl.scala
@@ -1,0 +1,6 @@
+package com.typesafe.conductr.clientlib.scala.models
+
+/**
+ * Represents declaration of request mappings for a given endpoint.
+ */
+case class RequestAcl(protocolFamilyRequestMappings: Set[ProtocolFamilyRequestMappings])

--- a/scala-conductr-client-lib/src/main/scala/com/typesafe/conductr/clientlib/scala/models/RequestMapping.scala
+++ b/scala-conductr-client-lib/src/main/scala/com/typesafe/conductr/clientlib/scala/models/RequestMapping.scala
@@ -1,0 +1,82 @@
+package com.typesafe.conductr.clientlib.scala.models
+
+/**
+ * Base type which represents request mapping for a particular endpoint.
+ */
+sealed trait RequestMapping
+
+object HttpRequestMapping {
+
+  /**
+   * HTTP request mapping to be matched based on the declared HTTP request path.
+   * @param path HTTP path to be matched.
+   * @param method optional - HTTP method to be matched
+   * @param rewrite optional - HTTP path to be rewritten to if matched
+   */
+  case class Path(path: String, method: Option[String] = None, rewrite: Option[String] = None) extends HttpRequestMapping
+
+  /**
+   * HTTP request mapping to be matched based for all paths that starts with given of HTTP request path.
+   * @param pathBeg given HTTP path - all paths which starts with this path are matched.
+   * @param method optional - HTTP method to be matched
+   * @param rewrite optional - HTTP path to be rewritten to if matched
+   */
+  case class PathBeg(pathBeg: String, method: Option[String] = None, rewrite: Option[String] = None) extends HttpRequestMapping
+
+  /**
+   * HTTP request mapping to be matched based on a particular regex pattern.
+   * @param pathRegex given regex pattern - all paths are considered matching if it matches this given pattern.
+   * @param method optional - HTTP method to be matched
+   * @param rewrite optional - HTTP path to be rewritten to if matched
+   */
+  case class PathRegex(pathRegex: String, method: Option[String] = None, rewrite: Option[String] = None) extends HttpRequestMapping
+}
+
+/**
+ * Base type which represents HTTP-based request mapping.
+ */
+trait HttpRequestMapping extends RequestMapping {
+  def method: Option[String]
+  def rewrite: Option[String]
+}
+
+/**
+ * Represents request mapping for a particular TCP port.
+ * @param port TCP port to be mapped
+ */
+case class TcpRequestMapping(port: Int) extends RequestMapping
+
+/**
+ * Represents request mapping for a particular UDP port.
+ * @param port UDP port to be mapped
+ */
+case class UdpRequestMapping(port: Int) extends RequestMapping
+
+/**
+ * Base type which represents request mapping for a given protocol family.
+ */
+trait ProtocolFamilyRequestMappings {
+  type Mapping <: RequestMapping
+  def requestMappings: Iterable[Mapping]
+}
+
+/**
+ * Base type which represents request mapping for a HTTP-based protocol family (i.e. HTTP or HTTPS).
+ */
+case class HttpFamilyRequestMappings(requestMappings: Seq[HttpRequestMapping]) extends ProtocolFamilyRequestMappings {
+  override type Mapping = HttpRequestMapping
+}
+
+/**
+ * Base type which represents request mapping for a TCP protocol family.
+ */
+case class TcpFamilyRequestMappings(requestMappings: Set[TcpRequestMapping]) extends ProtocolFamilyRequestMappings {
+  override type Mapping = TcpRequestMapping
+}
+
+/**
+ * Base type which represents request mapping for a UDP protocol family.
+ */
+case class UdpFamilyRequestMappings(requestMappings: Set[UdpRequestMapping]) extends ProtocolFamilyRequestMappings {
+  override type Mapping = UdpRequestMapping
+}


### PR DESCRIPTION
PR also includes the following changes:

- Removal of the `completeWhenInstalled` flag from `loadBundleComplete` - future always completes when bundle is installed.
- Removal of the `completeWhenScaleAchieved` flag from `runBundleComplete` - future always completes when desired bundle scale is achieved.
- Add unit test for `BundlesConnector`.