### PR TITLE
Enable cross publishing for Scala 2.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: scala
 scala:
 - 2.11.8
+jdk:
+- oraclejdk8
 script:
-- jdk_switcher use oraclejdk7
-- sbt conductRBundleLib/test:test scalaConductRBundleLib/test:test akka23ConductRBundleLib/test:test play23ConductRBundleLib/test:test scalaConductRClientLib/test:test play23ConductRClientLib/test:test
-- jdk_switcher use oraclejdk8
-- sbt test
+- sbt +test

--- a/akka23-common/build.sbt
+++ b/akka23-common/build.sbt
@@ -3,3 +3,5 @@ name := "akka23-conductr-lib-common"
 libraryDependencies ++= List(
   Library.akka23Http
 )
+
+crossScalaVersions := crossScalaVersions.value.filterNot(_.startsWith("2.12"))

--- a/akka23-conductr-bundle-lib/build.sbt
+++ b/akka23-conductr-bundle-lib/build.sbt
@@ -8,6 +8,8 @@ libraryDependencies ++= List(
   Library.scalaTest     % "test"
 )
 
+crossScalaVersions := crossScalaVersions.value.filterNot(_.startsWith("2.12"))
+
 fork in Test := true
 
 def groupByFirst(tests: Seq[TestDefinition]) =

--- a/akka23-test-lib/build.sbt
+++ b/akka23-test-lib/build.sbt
@@ -6,3 +6,5 @@ libraryDependencies ++= List(
   Library.junit,
   Library.scalaTest
 )
+
+crossScalaVersions := crossScalaVersions.value.filterNot(_.startsWith("2.12"))

--- a/akka24-conductr-client-lib/build.sbt
+++ b/akka24-conductr-client-lib/build.sbt
@@ -11,6 +11,10 @@ libraryDependencies ++= List(
   Library.scalaTest         % "test"
 )
 
+// Cannot use the client lib with 2.12 until Play also moves there, and we use an akka-sse
+// for 2.12.
+crossScalaVersions := crossScalaVersions.value.filterNot(_.startsWith("2.12"))
+
 fork in Test := true
 
 def groupByFirst(tests: Seq[TestDefinition]) =

--- a/build.sbt
+++ b/build.sbt
@@ -5,14 +5,17 @@ lazy val root = project
     conductRBundleLib,
     javaCommon,
     javaConductRBundleLib,
+    javaTestLib,
     scalaCommon,
     scalaConductRBundleLib,
     scalaConductRClientLib,
     akka23Common,
     akka23ConductRBundleLib,
+    akka23TestLib,
     akka24Common,
     akka24ConductRBundleLib,
     akka24ConductRClientLib,
+    akka24TestLib,
     play23Common,
     play23ConductRBundleLib,
     play23ConductRClientLib,
@@ -23,6 +26,7 @@ lazy val root = project
     play25ConductRBundleLib,
     play25ConductRClientLib,
     lagom1ConductRBundleLib)
+  .enablePlugins(CrossPerProjectPlugin)
 
 // When executing tests the projects are running sequentially.
 // If the tests of each project run sequentially or in parallel
@@ -33,17 +37,20 @@ concurrentRestrictions in Global += Tags.limit(Tags.Test, 1)
 // Base
 lazy val common = project
   .in(file("common"))
-  .dependsOn(akka23TestLib % "test->compile")
+  .dependsOn(akka24TestLib % "test->compile")
+  .enablePlugins(CrossPerProjectPlugin)
 
 lazy val conductRBundleLib = project
   .in(file("conductr-bundle-lib"))
   .dependsOn(common)
-  .dependsOn(akka23TestLib % "test->compile")
+  .dependsOn(akka24TestLib % "test->compile")
+  .enablePlugins(CrossPerProjectPlugin)
 
 // Java
 lazy val javaCommon = project
   .in(file("java-common"))
   .dependsOn(common)
+  .enablePlugins(CrossPerProjectPlugin)
 
 lazy val javaConductRBundleLib = project
   .in(file("java-conductr-bundle-lib"))
@@ -51,91 +58,107 @@ lazy val javaConductRBundleLib = project
   .dependsOn(javaCommon)
   .dependsOn(javaTestLib % "test->compile")
   .dependsOn(akka24TestLib % "test->compile")
+  .enablePlugins(CrossPerProjectPlugin)
 
 // Scala
 lazy val scalaCommon = project
   .in(file("scala-common"))
   .dependsOn(common)
+  .enablePlugins(CrossPerProjectPlugin)
 
 lazy val scalaConductRBundleLib = project
   .in(file("scala-conductr-bundle-lib"))
   .dependsOn(conductRBundleLib)
   .dependsOn(scalaCommon)
-  .dependsOn(akka23TestLib % "test->compile")
+  .dependsOn(akka24TestLib % "test->compile")
+  .enablePlugins(CrossPerProjectPlugin)
 
 lazy val scalaConductRClientLib = project
   .in(file("scala-conductr-client-lib"))
   .dependsOn(scalaCommon)
-  .dependsOn(akka23TestLib % "test->compile")
+  .dependsOn(akka24TestLib % "test->compile")
+  .enablePlugins(CrossPerProjectPlugin)
 
 // Akka 2.3
 lazy val akka23Common = project
   .in(file("akka23-common"))
   .dependsOn(scalaCommon)
+  .enablePlugins(CrossPerProjectPlugin)
 
 lazy val akka23ConductRBundleLib = project
   .in(file("akka23-conductr-bundle-lib"))
   .dependsOn(scalaConductRBundleLib)
   .dependsOn(akka23Common)
   .dependsOn(akka23TestLib % "test->compile")
+  .enablePlugins(CrossPerProjectPlugin)
 
 // Akka 2.4
 lazy val akka24Common = project
   .in(file("akka24-common"))
   .dependsOn(scalaCommon)
+  .enablePlugins(CrossPerProjectPlugin)
 
 lazy val akka24ConductRBundleLib = project
   .in(file("akka24-conductr-bundle-lib"))
   .dependsOn(scalaConductRBundleLib)
   .dependsOn(akka24Common)
   .dependsOn(akka24TestLib % "test->compile")
+  .enablePlugins(CrossPerProjectPlugin)
 
 lazy val akka24ConductRClientLib = project
   .in(file("akka24-conductr-client-lib"))
   .dependsOn(scalaConductRClientLib)
   .dependsOn(akka24Common)
   .dependsOn(akka24TestLib % "test->compile")
+  .enablePlugins(CrossPerProjectPlugin)
 
 // Play 2.3
 lazy val play23Common = project
   .in(file("play23-common"))
   .dependsOn(scalaCommon)
+  .enablePlugins(CrossPerProjectPlugin)
 
 lazy val play23ConductRBundleLib = project
   .in(file("play23-conductr-bundle-lib"))
   .dependsOn(akka23ConductRBundleLib)
   .dependsOn(play23Common)
   .dependsOn(akka23TestLib % "test->compile")
+  .enablePlugins(CrossPerProjectPlugin)
 
 lazy val play23ConductRClientLib = project
   .in(file("play23-conductr-client-lib"))
   .dependsOn(scalaConductRClientLib)
   .dependsOn(play23Common)
   .dependsOn(akka23TestLib % "test->compile")
+  .enablePlugins(CrossPerProjectPlugin)
 
 
 // Play 2.4
 lazy val play24Common = project
   .in(file("play24-common"))
   .dependsOn(scalaCommon)
+  .enablePlugins(CrossPerProjectPlugin)
 
 lazy val play24ConductRBundleLib = project
   .in(file("play24-conductr-bundle-lib"))
   .dependsOn(akka23ConductRBundleLib)
   .dependsOn(play24Common)
   .dependsOn(akka23TestLib % "test->compile")
+  .enablePlugins(CrossPerProjectPlugin)
 
 lazy val play24ConductRClientLib = project
   .in(file("play24-conductr-client-lib"))
   .dependsOn(scalaConductRClientLib)
   .dependsOn(play24Common)
   .dependsOn(akka23TestLib % "test->compile")
+  .enablePlugins(CrossPerProjectPlugin)
 
 // Play 2.5
 lazy val play25Common = project
   .in(file("play25-common"))
   .dependsOn(javaCommon)
   .dependsOn(scalaCommon)
+  .enablePlugins(CrossPerProjectPlugin)
 
 lazy val play25ConductRBundleLib = project
   .in(file("play25-conductr-bundle-lib"))
@@ -143,6 +166,7 @@ lazy val play25ConductRBundleLib = project
   .dependsOn(play25Common)
   .dependsOn(javaTestLib % "test->compile")
   .dependsOn(akka24TestLib % "test->compile")
+  .enablePlugins(CrossPerProjectPlugin)
 
 lazy val play25ConductRClientLib = project
   .in(file("play25-conductr-client-lib"))
@@ -150,6 +174,7 @@ lazy val play25ConductRClientLib = project
   .dependsOn(play25Common)
   .dependsOn(javaTestLib % "test->compile")
   .dependsOn(akka24TestLib % "test->compile")
+  .enablePlugins(CrossPerProjectPlugin)
 
 // Lagom version 1
 lazy val lagom1ConductRBundleLib = project
@@ -157,17 +182,21 @@ lazy val lagom1ConductRBundleLib = project
   .dependsOn(play25ConductRBundleLib)
   .dependsOn(javaTestLib % "test->compile")
   .dependsOn(akka24TestLib % "test->compile")
+  .enablePlugins(CrossPerProjectPlugin)
 
 
 // Test libraries
 lazy val akka23TestLib = project
   .in(file("akka23-test-lib"))
+  .enablePlugins(CrossPerProjectPlugin)
 
 lazy val akka24TestLib = project
   .in(file("akka24-test-lib"))
+  .enablePlugins(CrossPerProjectPlugin)
 
 lazy val javaTestLib = project
   .in(file("java-test-lib"))
+  .enablePlugins(CrossPerProjectPlugin)
 
 
 name := "root"

--- a/java-common/build.sbt
+++ b/java-common/build.sbt
@@ -7,3 +7,4 @@ unmanagedSourceDirectories in Compile := List((javaSource in Compile).value)
 
 autoScalaLibrary := false
 crossPaths := false
+crossScalaVersions := List(crossScalaVersions.value.head) // Requires building just the once

--- a/java-conductr-bundle-lib/build.sbt
+++ b/java-conductr-bundle-lib/build.sbt
@@ -14,6 +14,7 @@ unmanagedSourceDirectories in Compile := List((javaSource in Compile).value)
 
 autoScalaLibrary := false
 crossPaths := false
+crossScalaVersions := List(crossScalaVersions.value.head) // Requires building just the once
 
 fork in Test := true
 

--- a/java-test-lib/build.sbt
+++ b/java-test-lib/build.sbt
@@ -1,3 +1,4 @@
 name := "java-test-lib"
 
 scalacOptions += "-target:jvm-1.8"
+crossScalaVersions := List(crossScalaVersions.value.head) // Requires building just the once

--- a/lagom1-conductr-bundle-lib/build.sbt
+++ b/lagom1-conductr-bundle-lib/build.sbt
@@ -9,6 +9,8 @@ libraryDependencies ++= List(
   Library.scalaTest     % "test"
 )
 
+crossScalaVersions := crossScalaVersions.value.filterNot(_.startsWith("2.12"))
+
 fork in Test := true
 
 def groupByFirst(tests: Seq[TestDefinition]) =

--- a/play23-common/build.sbt
+++ b/play23-common/build.sbt
@@ -5,3 +5,6 @@ libraryDependencies ++= List(
 )
 
 resolvers += Resolvers.typesafeReleases // For netty-http-pipeline
+
+crossScalaVersions := crossScalaVersions.value.filterNot(_.startsWith("2.12"))
+scalacOptions += "-target:jvm-1.6"

--- a/play23-conductr-bundle-lib/build.sbt
+++ b/play23-conductr-bundle-lib/build.sbt
@@ -8,6 +8,9 @@ libraryDependencies ++= List(
   Library.scalaTest     % "test"
 )
 
+crossScalaVersions := crossScalaVersions.value.filterNot(_.startsWith("2.12"))
+scalacOptions += "-target:jvm-1.6"
+
 fork in Test := true
 
 def groupByFirst(tests: Seq[TestDefinition]) =

--- a/play23-conductr-client-lib/build.sbt
+++ b/play23-conductr-client-lib/build.sbt
@@ -1,1 +1,4 @@
 name := "play23-conductr-client-lib"
+
+crossScalaVersions := crossScalaVersions.value.filterNot(_.startsWith("2.12"))
+scalacOptions += "-target:jvm-1.6"

--- a/play24-common/build.sbt
+++ b/play24-common/build.sbt
@@ -3,3 +3,5 @@ name := "play24-conductr-lib-common"
 libraryDependencies ++= List(
   Library.play24Ws
 )
+
+crossScalaVersions := crossScalaVersions.value.filterNot(_.startsWith("2.12"))

--- a/play24-conductr-bundle-lib/build.sbt
+++ b/play24-conductr-bundle-lib/build.sbt
@@ -8,6 +8,8 @@ libraryDependencies ++= List(
   Library.scalaTest     % "test"
 )
 
+crossScalaVersions := crossScalaVersions.value.filterNot(_.startsWith("2.12"))
+
 fork in Test := true
 
 def groupByFirst(tests: Seq[TestDefinition]) =

--- a/play24-conductr-client-lib/build.sbt
+++ b/play24-conductr-client-lib/build.sbt
@@ -1,1 +1,3 @@
 name := "play24-conductr-client-lib"
+
+crossScalaVersions := crossScalaVersions.value.filterNot(_.startsWith("2.12"))

--- a/play25-common/build.sbt
+++ b/play25-common/build.sbt
@@ -3,3 +3,5 @@ name := "play25-conductr-lib-common"
 libraryDependencies ++= List(
   Library.play25Ws
 )
+
+crossScalaVersions := crossScalaVersions.value.filterNot(_.startsWith("2.12"))

--- a/play25-conductr-bundle-lib/build.sbt
+++ b/play25-conductr-bundle-lib/build.sbt
@@ -9,6 +9,8 @@ libraryDependencies ++= List(
   Library.scalaTest     % "test"
 )
 
+crossScalaVersions := crossScalaVersions.value.filterNot(_.startsWith("2.12"))
+
 fork in Test := true
 
 def groupByFirst(tests: Seq[TestDefinition]) =

--- a/play25-conductr-client-lib/build.sbt
+++ b/play25-conductr-client-lib/build.sbt
@@ -1,1 +1,3 @@
 name := "play25-conductr-client-lib"
+
+crossScalaVersions := crossScalaVersions.value.filterNot(_.startsWith("2.12"))

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -21,13 +21,13 @@ object Build extends AutoPlugin {
       // Core settings
       organization := "com.typesafe.conductr",
       scalaVersion := Version.scala,
-      crossScalaVersions := List(scalaVersion.value, "2.10.4"),
+      crossScalaVersions := List(scalaVersion.value, "2.12.1"),
       scalacOptions ++= List(
         "-unchecked",
         "-deprecation",
         "-feature",
         "-language:_",
-        "-target:jvm-1.6",
+        "-target:jvm-1.8",
         "-encoding", "UTF-8"
       ),
       homepage := Some(url("http://conductr.lightbend.com/")),
@@ -45,6 +45,12 @@ object Build extends AutoPlugin {
       // Sonatype settings
       sonatypeProfileName := "com.typesafe",
       // Release settings
-      releasePublishArtifactsAction := publishSigned.value
+      releasePublishArtifactsAction := publishSigned.value,
+      releaseCrossBuild := false,
+      releaseIgnoreUntrackedFiles := true,
+      releaseProcess := Seq[ReleaseStep](
+        releaseStepCommandAndRemaining("+publish")
+      )
+
     )
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ object Version {
   val lagom1             = "1.2.0"
   val reactiveStreams    = "1.0.0"
   val scala              = "2.11.8"
-  val scalaTest          = "2.2.6"
+  val scalaTest          = "3.0.1"
 }
 
 object Library {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.9
+sbt.version = 0.13.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,5 @@
-addSbtPlugin("com.github.gseitz" % "sbt-release"     % "1.0.3")
+addSbtPlugin("com.github.gseitz" % "sbt-release"     % "1.0.4")
 addSbtPlugin("org.scalariform"   % "sbt-scalariform" % "1.6.0")
 addSbtPlugin("com.jsuereth"      % "sbt-pgp"         % "1.0.0")
 addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype"    % "1.1")
+addSbtPlugin("com.eed3si9n"      % "sbt-doge"        % "0.1.5")

--- a/scala-conductr-bundle-lib/build.sbt
+++ b/scala-conductr-bundle-lib/build.sbt
@@ -3,8 +3,8 @@ import Tests._
 name := "scala-conductr-bundle-lib"
 
 libraryDependencies ++= List(
-  Library.akka23HttpTestkit % "test",
-  Library.akka23Testkit     % "test",
+  Library.akka24HttpTestkit % "test",
+  Library.akka24Testkit     % "test",
   Library.scalaTest         % "test"
 )
 

--- a/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/LocationServiceSpecWithEnv.scala
+++ b/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/LocationServiceSpecWithEnv.scala
@@ -94,7 +94,7 @@ class LocationServiceSpecWithEnv extends AkkaUnitTestWithFixture("LocationServic
     val probe = new TestProbe(system)
 
     val handler =
-      path("services" / Rest) { serviceName =>
+      path("services" / Remaining) { serviceName =>
         get {
           complete {
             serviceName match {


### PR DESCRIPTION
Specifically excludes projects in the cross build that do not, or indeed will not support Scala 2.12.

I'm unsure if this is totally correct, but I can `+ test` from the root project and it will compile/test correct for both 2.11 and 2.12. We won't know if the publish/release actually works until we try it, and this PR needs to be merged before that can happen.

[`sbt-doge`](https://github.com/sbt/sbt-doge) is used to solve a cross building problem within sbt.