### PR TITLE
Include releasing to maven into sbt release

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -46,20 +46,20 @@ object Build extends AutoPlugin {
       // Sonatype settings
       sonatypeProfileName := "com.typesafe",
       // Release settings
-      releasePublishArtifactsAction := publishSigned.value,
-      releaseCrossBuild := false,
+      releaseCrossBuild := true,
       releaseIgnoreUntrackedFiles := true,
       releaseProcess := Seq[ReleaseStep](
         checkSnapshotDependencies,
         inquireVersions,
         runClean,
-        releaseStepCommandAndRemaining("+test"),
+        runTest,
         setReleaseVersion,
         commitReleaseVersion,
         tagRelease,
-        releaseStepCommandAndRemaining("+publishSigned"),
+        ReleaseStep(action = Command.process("publishSigned", _), enableCrossBuild = true),
         setNextVersion,
         commitNextVersion,
+        ReleaseStep(action = Command.process("sonatypeReleaseAll", _), enableCrossBuild = true),
         pushChanges
       )
     )


### PR DESCRIPTION
So far the `sbt release` command was not closing and releasing the published artifacts on sonatype.

This PR is changing the `releaseProcess` task so that `sbt release` also releases the artifacts to sonatype.

The release process is now similar as for `constructr-zookeeper` in which this steps have been already battle tested: https://github.com/typesafehub/constructr-zookeeper/blob/master/project/Build.scala#L59-L73