### PR TITLE
WIP - DON'T MERGE: Provide dependencies

### DIFF
--- a/akka23-common/build.sbt
+++ b/akka23-common/build.sbt
@@ -1,7 +1,7 @@
 name := "akka23-conductr-lib-common"
 
 libraryDependencies ++= List(
-  Library.akka23Http
+  Library.akka23Http % "provided"
 )
 
 crossScalaVersions := crossScalaVersions.value.filterNot(_.startsWith("2.12"))

--- a/akka23-conductr-bundle-lib/build.sbt
+++ b/akka23-conductr-bundle-lib/build.sbt
@@ -3,7 +3,9 @@ import Tests._
 name := "akka23-conductr-bundle-lib"
 
 libraryDependencies ++= List(
-  Library.akka23Cluster,
+  // Adding akka23Http here is necessary because akka23-common is adding the library as 'provided'
+  Library.akka23Http    % "provided",
+  Library.akka23Cluster % "provided",
   Library.akka23Testkit % "test",
   Library.scalaTest     % "test"
 )
@@ -12,7 +14,7 @@ crossScalaVersions := crossScalaVersions.value.filterNot(_.startsWith("2.12"))
 
 fork in Test := true
 
-def groupByFirst(tests: Seq[TestDefinition]) =
+def groupByFirst(tests: Seq[TestDefinition]): Seq[Group] =
   tests
     .groupBy(t => t.name.drop(t.name.indexOf("WithEnv")))
     .map {

--- a/akka24-common/build.sbt
+++ b/akka24-common/build.sbt
@@ -1,5 +1,5 @@
 name := "akka24-conductr-lib-common"
 
 libraryDependencies ++= List(
-  Library.akka24Http
+  Library.akka24Http % "provided"
 )

--- a/akka24-conductr-bundle-lib/build.sbt
+++ b/akka24-conductr-bundle-lib/build.sbt
@@ -3,7 +3,9 @@ import Tests._
 name := "akka24-conductr-bundle-lib"
 
 libraryDependencies ++= List(
-  Library.akka24Cluster,
+  // Adding akka24Http here is necessary because akka24-common is adding the library as 'provided'
+  Library.akka24Http    % "provided",
+  Library.akka24Cluster % "provided",
   Library.akka24Testkit % "test",
   Library.scalaTest     % "test"
 )

--- a/akka24-conductr-client-lib/build.sbt
+++ b/akka24-conductr-client-lib/build.sbt
@@ -3,6 +3,8 @@ import Tests._
 name := "akka24-conductr-client-lib"
 
 libraryDependencies ++= List(
+  // Adding akka24Http here is necessary because akka24-common is adding the library as 'provided'
+  Library.akka24Http        % "provided",
   Library.akka24Sse,
   Library.play25Json,
   Library.akka24HttpTestkit % "test",

--- a/lagom1-java-conductr-bundle-lib/build.sbt
+++ b/lagom1-java-conductr-bundle-lib/build.sbt
@@ -3,7 +3,7 @@ import Tests._
 name := "lagom1-java-conductr-bundle-lib"
 
 libraryDependencies ++= List(
-  Library.lagom1ClientJavadsl,
+  Library.lagom1ClientJavadsl % "provided",
   Library.akka24Testkit % "test",
   Library.play25Test    % "test",
   Library.scalaTest     % "test"

--- a/lagom1-scala-conductr-bundle-lib/build.sbt
+++ b/lagom1-scala-conductr-bundle-lib/build.sbt
@@ -3,7 +3,7 @@ import Tests._
 name := "lagom1-scala-conductr-bundle-lib"
 
 libraryDependencies ++= List(
-  Library.lagom1ClientScaladsl,
+  Library.lagom1ClientScaladsl % "provided",
   Library.lagom1ServerScaladsl % "test",
   Library.akka24Testkit        % "test",
   Library.play25Test           % "test",

--- a/play23-common/build.sbt
+++ b/play23-common/build.sbt
@@ -1,7 +1,7 @@
 name := "play23-conductr-lib-common"
 
 libraryDependencies ++= List(
-  Library.play23Ws
+  Library.play23Ws % "provided"
 )
 
 resolvers += Resolvers.typesafeReleases // For netty-http-pipeline

--- a/play23-conductr-bundle-lib/build.sbt
+++ b/play23-conductr-bundle-lib/build.sbt
@@ -3,6 +3,8 @@ import Tests._
 name := "play23-conductr-bundle-lib"
 
 libraryDependencies ++= List(
+  // Adding play23Ws here is necessary because play23-common is adding the library as 'provided'
+  Library.play23Ws      % "provided",
   Library.akka23Testkit % "test",
   Library.play23Test    % "test",
   Library.scalaTest     % "test"

--- a/play24-common/build.sbt
+++ b/play24-common/build.sbt
@@ -1,7 +1,7 @@
 name := "play24-conductr-lib-common"
 
 libraryDependencies ++= List(
-  Library.play24Ws
+  Library.play24Ws % "provided"
 )
 
 crossScalaVersions := crossScalaVersions.value.filterNot(_.startsWith("2.12"))

--- a/play24-conductr-bundle-lib/build.sbt
+++ b/play24-conductr-bundle-lib/build.sbt
@@ -3,6 +3,8 @@ import Tests._
 name := "play24-conductr-bundle-lib"
 
 libraryDependencies ++= List(
+  // Adding play24Ws here is necessary because play24-common is adding the library as 'provided'
+  Library.play24Ws      % "provided",
   Library.akka23Testkit % "test",
   Library.play24Test    % "test",
   Library.scalaTest     % "test"

--- a/play25-common/build.sbt
+++ b/play25-common/build.sbt
@@ -1,7 +1,7 @@
 name := "play25-conductr-lib-common"
 
 libraryDependencies ++= List(
-  Library.play25Ws
+  Library.play25Ws % "provided"
 )
 
 crossScalaVersions := crossScalaVersions.value.filterNot(_.startsWith("2.12"))

--- a/play25-conductr-bundle-lib/build.sbt
+++ b/play25-conductr-bundle-lib/build.sbt
@@ -3,6 +3,8 @@ import Tests._
 name := "play25-conductr-bundle-lib"
 
 libraryDependencies ++= List(
+  // Adding play25Ws here is necessary because play25-common is adding the library as 'provided'
+  Library.play25Ws      % "provided",
   Library.java8Compat,
   Library.akka24Testkit % "test",
   Library.play25Test    % "test",


### PR DESCRIPTION
Does not publish the following dependent dependencies anymore (all supported versions):
- akka-cluster
- akka-http-experimental
- akka-http
- play-ws
- lagom-javadsl-client
- lagom-scaladsl-client

This is achieved by using the `provided` scope when adding the dependencies.

Addresses https://github.com/typesafehub/conductr-lib/issues/127