### PR TITLE
Removing sbt deprecation warnings

### DIFF
--- a/akka23-conductr-bundle-lib/build.sbt
+++ b/akka23-conductr-bundle-lib/build.sbt
@@ -55,4 +55,4 @@ def groupByFirst(tests: Seq[TestDefinition]) =
         new Group("WithoutEnv", t, SubProcess(ForkOptions()))
     }.toSeq
 
-testGrouping in Test <<= (definedTests in Test).map(groupByFirst)
+testGrouping in Test := { (definedTests in Test).map(groupByFirst).value }

--- a/akka24-conductr-bundle-lib/build.sbt
+++ b/akka24-conductr-bundle-lib/build.sbt
@@ -53,4 +53,4 @@ def groupByFirst(tests: Seq[TestDefinition]) =
         new Group("WithoutEnv", t, SubProcess(ForkOptions()))
     }.toSeq
 
-testGrouping in Test <<= (definedTests in Test).map(groupByFirst)
+testGrouping in Test := { (definedTests in Test).map(groupByFirst).value }

--- a/akka24-conductr-client-lib/build.sbt
+++ b/akka24-conductr-client-lib/build.sbt
@@ -60,6 +60,6 @@ def groupByFirst(tests: Seq[TestDefinition]) =
         new Group("WithoutEnv", t, SubProcess(ForkOptions()))
     }.toSeq
 
-testGrouping in Test <<= (definedTests in Test).map(groupByFirst)
+testGrouping in Test := { (definedTests in Test).map(groupByFirst).value }
 
 resolvers += Resolvers.typesafeReleases // For akka-contrib-extra within test code

--- a/java-conductr-bundle-lib/build.sbt
+++ b/java-conductr-bundle-lib/build.sbt
@@ -32,4 +32,4 @@ def groupByFirst(tests: Seq[TestDefinition]) =
     }
     .toSeq
 
-testGrouping in Test <<= (definedTests in Test).map(groupByFirst)
+testGrouping in Test := { (definedTests in Test).map(groupByFirst).value }

--- a/lagom1-java-conductr-bundle-lib/build.sbt
+++ b/lagom1-java-conductr-bundle-lib/build.sbt
@@ -27,4 +27,4 @@ def groupByFirst(tests: Seq[TestDefinition]) =
         ))))
     }.toSeq
 
-testGrouping in Test <<= (definedTests in Test).map(groupByFirst)
+testGrouping in Test := { (definedTests in Test).map(groupByFirst).value }

--- a/lagom1-scala-conductr-bundle-lib/build.sbt
+++ b/lagom1-scala-conductr-bundle-lib/build.sbt
@@ -28,4 +28,4 @@ def groupByFirst(tests: Seq[TestDefinition]) =
         ))))
     }.toSeq
 
-testGrouping in Test <<= (definedTests in Test).map(groupByFirst)
+testGrouping in Test := { (definedTests in Test).map(groupByFirst).value }

--- a/play23-conductr-bundle-lib/build.sbt
+++ b/play23-conductr-bundle-lib/build.sbt
@@ -31,4 +31,4 @@ def groupByFirst(tests: Seq[TestDefinition]) =
         new Group("WithoutEnv", t, SubProcess(ForkOptions()))
     }.toSeq
 
-testGrouping in Test <<= (definedTests in Test).map(groupByFirst)
+testGrouping in Test := { (definedTests in Test).map(groupByFirst).value }

--- a/play24-conductr-bundle-lib/build.sbt
+++ b/play24-conductr-bundle-lib/build.sbt
@@ -30,4 +30,4 @@ def groupByFirst(tests: Seq[TestDefinition]) =
         new Group("WithoutEnv", t, SubProcess(ForkOptions()))
     }.toSeq
 
-testGrouping in Test <<= (definedTests in Test).map(groupByFirst)
+testGrouping in Test := { (definedTests in Test).map(groupByFirst).value }

--- a/play25-conductr-bundle-lib/build.sbt
+++ b/play25-conductr-bundle-lib/build.sbt
@@ -31,4 +31,4 @@ def groupByFirst(tests: Seq[TestDefinition]) =
         new Group("WithoutEnv", t, SubProcess(ForkOptions()))
     }.toSeq
 
-testGrouping in Test <<= (definedTests in Test).map(groupByFirst)
+testGrouping in Test := { (definedTests in Test).map(groupByFirst).value }

--- a/scala-conductr-bundle-lib/build.sbt
+++ b/scala-conductr-bundle-lib/build.sbt
@@ -24,4 +24,4 @@ def groupByFirst(tests: Seq[TestDefinition]) =
     }
     .toSeq
 
-testGrouping in Test <<= (definedTests in Test).map(groupByFirst)
+testGrouping in Test := { (definedTests in Test).map(groupByFirst).value }


### PR DESCRIPTION
The following deprecation warnings have been introduced with the upgrade to SBT 0.13.13:

```
/Users/mj/workspace/conductr-lib/scala-conductr-bundle-lib/build.sbt:27: warning: `<<=` operator is deprecated. Use `key := { x.value }` or `key ~= (old => { newValue })`.
See http://www.scala-sbt.org/0.13/docs/Migrating-from-sbt-012x.html
testGrouping in Test <<= (definedTests in Test).map(groupByFirst)
```

This PR is removing the warning by using the following style:

```
testGrouping in Test := { (definedTests in Test).map(groupByFirst).value }
```