### PR TITLE
Client Lib: implement method to obtain BundleDescriptor

### DIFF
--- a/akka24-conductr-client-lib/src/main/scala/com/typesafe/conductr/clientlib/akka/JsonMarshalling.scala
+++ b/akka24-conductr-client-lib/src/main/scala/com/typesafe/conductr/clientlib/akka/JsonMarshalling.scala
@@ -90,7 +90,7 @@ object JsonMarshalling {
 
     override def reads(json: JsValue): JsResult[TcpFamilyRequestMappings] =
       for {
-        ports <- (json \ "requests").validate[Set[Int]]
+        ports <- (json \ "requests").validate[Seq[Int]]
       } yield TcpFamilyRequestMappings(ports.map(TcpRequestMapping))
   }
 
@@ -100,7 +100,7 @@ object JsonMarshalling {
 
     override def reads(json: JsValue): JsResult[UdpFamilyRequestMappings] =
       for {
-        ports <- (json \ "requests").validate[Set[Int]]
+        ports <- (json \ "requests").validate[Seq[Int]]
       } yield UdpFamilyRequestMappings(ports.map(UdpRequestMapping))
   }
 
@@ -128,17 +128,17 @@ object JsonMarshalling {
       } yield HttpFamilyRequestMappings(requestMappings)
   }
 
-  implicit object ProtocolFamilyRequestMappingsFormat extends Format[Set[ProtocolFamilyRequestMappings]] {
-    override def writes(o: Set[ProtocolFamilyRequestMappings]): JsValue =
+  implicit object ProtocolFamilyRequestMappingsFormat extends Format[Seq[ProtocolFamilyRequestMappings]] {
+    override def writes(o: Seq[ProtocolFamilyRequestMappings]): JsValue =
       throw new UnsupportedOperationException()
 
-    override def reads(json: JsValue): JsResult[Set[ProtocolFamilyRequestMappings]] =
+    override def reads(json: JsValue): JsResult[Seq[ProtocolFamilyRequestMappings]] =
       for {
         httpRequestMappings <- (json \ "http").validateOpt[HttpFamilyRequestMappings]
         tcpRequestMappings <- (json \ "tcp").validateOpt[TcpFamilyRequestMappings]
         udpRequestMappings <- (json \ "udp").validateOpt[UdpFamilyRequestMappings]
       } yield {
-        Set(httpRequestMappings, tcpRequestMappings, udpRequestMappings)
+        Seq(httpRequestMappings, tcpRequestMappings, udpRequestMappings)
           .collect {
             case Some(value) => value
           }
@@ -151,7 +151,7 @@ object JsonMarshalling {
 
     override def reads(json: JsValue): JsResult[RequestAcl] =
       for {
-        jsonValues <- json.validate[Set[ProtocolFamilyRequestMappings]]
+        jsonValues <- json.validate[Seq[ProtocolFamilyRequestMappings]]
       } yield RequestAcl(jsonValues)
   }
 

--- a/akka24-conductr-client-lib/src/test/scala/com/typesafe/conductr/clientlib/akka/ControlClientSpec.scala
+++ b/akka24-conductr-client-lib/src/test/scala/com/typesafe/conductr/clientlib/akka/ControlClientSpec.scala
@@ -637,10 +637,10 @@ class ControlClientSpec extends AkkaUnitTestWithFixture("ControlClientSpec") wit
             interval = 800.millis,
             tick = Seq(
               ServerSentEvent(s"${BundleFrontend.bundleId}", "bundleInstallationAdded"),
-              ServerSentEvent.heartbeat,
-              ServerSentEvent.heartbeat,
-              ServerSentEvent.heartbeat,
-              ServerSentEvent.heartbeat
+              ServerSentEvent.Heartbeat,
+              ServerSentEvent.Heartbeat,
+              ServerSentEvent.Heartbeat,
+              ServerSentEvent.Heartbeat
             )
           ).mapConcat(identity)
         )
@@ -745,10 +745,10 @@ class ControlClientSpec extends AkkaUnitTestWithFixture("ControlClientSpec") wit
             interval = 800.millis,
             tick = Seq(
               ServerSentEvent(s"${BundleFrontend.bundleId}", "bundleInstallationAdded"),
-              ServerSentEvent.heartbeat,
-              ServerSentEvent.heartbeat,
-              ServerSentEvent.heartbeat,
-              ServerSentEvent.heartbeat
+              ServerSentEvent.Heartbeat,
+              ServerSentEvent.Heartbeat,
+              ServerSentEvent.Heartbeat,
+              ServerSentEvent.Heartbeat
             )
           ).mapConcat(identity)
         )
@@ -882,10 +882,10 @@ class ControlClientSpec extends AkkaUnitTestWithFixture("ControlClientSpec") wit
             interval = 800.millis,
             tick = Seq(
               ServerSentEvent(s"${BundleFrontend.bundleId}", "bundleExecutionAdded"),
-              ServerSentEvent.heartbeat,
-              ServerSentEvent.heartbeat,
-              ServerSentEvent.heartbeat,
-              ServerSentEvent.heartbeat
+              ServerSentEvent.Heartbeat,
+              ServerSentEvent.Heartbeat,
+              ServerSentEvent.Heartbeat,
+              ServerSentEvent.Heartbeat
             )
           ).mapConcat(identity)
         )
@@ -971,10 +971,10 @@ class ControlClientSpec extends AkkaUnitTestWithFixture("ControlClientSpec") wit
             interval = 800.millis,
             tick = Seq(
               ServerSentEvent(s"${BundleFrontend.bundleId}", "bundleExecutionAdded"),
-              ServerSentEvent.heartbeat,
-              ServerSentEvent.heartbeat,
-              ServerSentEvent.heartbeat,
-              ServerSentEvent.heartbeat
+              ServerSentEvent.Heartbeat,
+              ServerSentEvent.Heartbeat,
+              ServerSentEvent.Heartbeat,
+              ServerSentEvent.Heartbeat
             )
           ).mapConcat(identity)
         )

--- a/akka24-conductr-client-lib/src/test/scala/com/typesafe/conductr/clientlib/akka/TestData.scala
+++ b/akka24-conductr-client-lib/src/test/scala/com/typesafe/conductr/clientlib/akka/TestData.scala
@@ -263,7 +263,7 @@ object TestData {
     bundleConfig = Some(BundleConfig(Map(
       "old-hub" -> BundleConfigEndpoint("http", Some("old-hub"), Set(new URI("http://:5555/hub1")), Seq.empty),
       "hub" -> BundleConfigEndpoint("http", Some("hub"), Set.empty, Seq(
-        RequestAcl(Set(
+        RequestAcl(Seq(
           HttpFamilyRequestMappings(Seq(
             Path("/path-1"),
             Path("/path-2", method = Some("GET"), rewrite = Some("/other-path-2")),
@@ -275,15 +275,15 @@ object TestData {
         ))
       )),
       "tunnel" -> BundleConfigEndpoint("tcp", None, Set.empty, Seq(
-        RequestAcl(Set(
-          TcpFamilyRequestMappings(Set(
+        RequestAcl(Seq(
+          TcpFamilyRequestMappings(Seq(
             TcpRequestMapping(7001)
           ))
         ))
       )),
       "broadcast" -> BundleConfigEndpoint("udp", None, Set.empty, Seq(
-        RequestAcl(Set(
-          UdpFamilyRequestMappings(Set(
+        RequestAcl(Seq(
+          UdpFamilyRequestMappings(Seq(
             UdpRequestMapping(5001)
           ))
         ))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,6 +18,7 @@ object Version {
   val play25             = "2.5.12"
   val lagom1             = "1.3.0-RC2"
   val reactiveStreams    = "1.0.0"
+  val typesafeConfig     = "1.3.0"
   val scala              = "2.11.8"
   val scalaTest          = "3.0.1"
 }
@@ -50,6 +51,7 @@ object Library {
   val play25Test         = "com.typesafe.play"      %% "play-test"                      % Version.play25
   val play25Json         = "com.typesafe.play"      %% "play-json"                      % Version.play25
   val play25Ws           = "com.typesafe.play"      %% "play-ws"                        % Version.play25
+  val typesafeConfig     = "com.typesafe"           %  "config"                         % Version.typesafeConfig
   val scalaTest          = "org.scalatest"          %% "scalatest"                      % Version.scalaTest
 }
 

--- a/scala-conductr-client-lib/build.sbt
+++ b/scala-conductr-client-lib/build.sbt
@@ -1,5 +1,7 @@
 name := "scala-conductr-client-lib"
 
 libraryDependencies ++= List(
-  Library.reactiveStreams
+  Library.reactiveStreams,
+  Library.typesafeConfig,
+  Library.scalaTest         % "test"
 )

--- a/scala-conductr-client-lib/src/main/scala/com/typesafe/conductr/clientlib/scala/models/BundleDescriptor.scala
+++ b/scala-conductr-client-lib/src/main/scala/com/typesafe/conductr/clientlib/scala/models/BundleDescriptor.scala
@@ -1,0 +1,194 @@
+package com.typesafe.conductr.clientlib.scala.models
+
+import java.util
+
+import com.typesafe.config._
+
+import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
+import scala.collection.breakOut
+import scala.util.Try
+
+object BundleDescriptor {
+
+  val EmptyAnnotations: ConfigObject =
+    ConfigValueFactory.fromMap(new util.HashMap[String, Object]())
+
+  case class MalformedBundleConfException(description: String) extends Exception(description)
+
+  object Component {
+
+    sealed trait FileSystemType
+
+    object FileSystemType {
+      case object Universal extends FileSystemType
+      case object Docker extends FileSystemType
+
+      def apply(s: String): FileSystemType =
+        s.toLowerCase match {
+          case "universal" => Universal
+          case "docker"    => Docker
+        }
+    }
+
+    case class Endpoint(
+      bindProtocol: String,
+      bindPort: Int,
+      serviceName: Option[String],
+      requestAcls: Seq[RequestAcl]
+    )
+
+    def apply(config: Config): Component = {
+      val endpointsObj = config.getObject("endpoints")
+      Component(
+        config.getString("description"),
+        FileSystemType(config.getString("file-system-type")),
+        config.getStringList("start-command").asScala.toList,
+        endpointsObj.keySet.asScala.map { name =>
+          val endpoint = endpointsObj.get(name).asInstanceOf[ConfigObject].toConfig
+
+          val serviceName = if (endpoint.hasPath("service-name"))
+            Option(endpoint.getString("service-name")).filter(_.nonEmpty)
+          else
+            None
+
+          val requestAcls = if (endpoint.hasPath("acls"))
+            endpoint.getConfigList("acls").map(parseRequestAcl)
+          else
+            Seq.empty[RequestAcl]
+
+          name -> Endpoint(
+            endpoint.getString("bind-protocol"),
+            endpoint.getInt("bind-port"),
+            serviceName,
+            requestAcls
+          )
+        }(breakOut)
+      )
+    }
+
+    private def parseRequestAcl(config: Config): RequestAcl =
+      RequestAcl(
+        config.entrySet()
+          .map(_.getKey.split('.').toSeq)
+          .collect {
+            case Seq(protocol @ "http", configKey @ "requests") =>
+              val requestMappingsConfigs = config.getConfig(protocol).getConfigList(configKey).toList
+              HttpFamilyRequestMappings(requestMappingsConfigs.map(parseHttpRequestMapping))
+
+            case Seq(protocol @ "tcp", configKey @ "requests") =>
+              val ports = config.getConfig(protocol).getIntList(configKey)
+              TcpFamilyRequestMappings(ports.map(TcpRequestMapping(_)))
+
+            case Seq(protocol @ "udp", configKey @ "requests") =>
+              val ports = config.getConfig(protocol).getIntList(configKey)
+              UdpFamilyRequestMappings(ports.map(UdpRequestMapping(_)))
+          }
+          .foldLeft(Seq.empty[ProtocolFamilyRequestMappings])(_ :+ _)
+      )
+
+    private def parseHttpRequestMapping(config: Config): HttpRequestMapping = {
+      def getOptString(key: String): Option[String] =
+        if (config.hasPath(key)) Some(config.getString(key)) else None
+
+      val method = getOptString("method")
+
+      (getOptString("path"), getOptString("path-beg"), getOptString("path-regex"), getOptString("rewrite")) match {
+        case (Some(path), None, None, rewrite) =>
+          HttpRequestMapping.Path(path, method, rewrite)
+        case (None, Some(pathBeg), None, rewrite) =>
+          HttpRequestMapping.PathBeg(pathBeg, method, rewrite)
+        case (None, None, Some(pathRegex), rewrite) =>
+          HttpRequestMapping.PathRegex(pathRegex, method, rewrite)
+        case _ =>
+          throw MalformedBundleConfException(s"Either path, path-beg, or path-regex must be present")
+      }
+    }
+  }
+
+  /**
+   * Represents a component in a bundle.conf file.
+   */
+  case class Component(
+    description: String,
+    fileSystemType: Component.FileSystemType,
+    startCommand: Seq[String],
+    endpoints: Map[String, Component.Endpoint]
+  )
+
+  final val BundleConf = "bundle.conf"
+
+  object ConfigKeys {
+
+    // Support camel case identifiers for backward compatibility pre 2.1.
+    private def camelCase(id: String): String =
+      id
+        .foldLeft((new StringBuilder(id.length), false)) {
+          case ((a, _), c) if c == '-' => (a, true)
+          case ((a, n), c) if n        => (a.append(c.toUpper), false)
+          case ((a, _), c)             => (a.append(c), false)
+        }
+        ._1
+        .toString
+
+    final val Version = "version"
+    final val System = "system"
+    final val SystemVersion = "system-version"
+    final val SystemVersionCamelCase = camelCase(SystemVersion)
+    final val NrOfCpus = "nr-of-cpus"
+    final val NrOfCpusCamelCase = camelCase(NrOfCpus)
+    final val Memory = "memory"
+    final val DiskSpace = "disk-space"
+    final val DiskSpaceCamelCase = camelCase(DiskSpace)
+    final val Roles = "roles"
+    final val BundleName = "name"
+    final val CompatibilityVersion = "compatibility-version"
+    final val CompatibilityVersionCamelCase = camelCase(CompatibilityVersion)
+    final val Tags = "tags"
+    final val Annotations = "annotations"
+  }
+
+  def fromConfig(input: ConfigObject): BundleDescriptor = {
+    import ConfigKeys._
+
+    val config = input.toConfig
+    val componentsObj = config.getObject("components")
+    val system = config.getString(System)
+    BundleDescriptor(
+      config.getString(Version),
+      system,
+      Try(config.getString(SystemVersion)).getOrElse(config.getString(SystemVersionCamelCase)),
+      Try(config.getDouble(NrOfCpus)).getOrElse(config.getDouble(NrOfCpusCamelCase)),
+      config.getLong(Memory),
+      Try(config.getLong(DiskSpace)).getOrElse(config.getLong(DiskSpaceCamelCase)),
+      config.getStringList(Roles).asScala,
+      config.getString(BundleName),
+      Try(config.getString(CompatibilityVersion)).getOrElse(config.getString(CompatibilityVersionCamelCase)),
+      Try(config.getStringList(Tags).to[List]).getOrElse(List.empty),
+      if (config.hasPath(Annotations)) Some(Try(config.getObject(Annotations)).getOrElse(EmptyAnnotations)) else None,
+      componentsObj.keySet.asScala.map { name =>
+        name -> Component(componentsObj.get(name).asInstanceOf[ConfigObject].toConfig)
+      }(breakOut)
+    )
+  }
+
+}
+
+/**
+ * Represents a bundle.conf file.
+ */
+case class BundleDescriptor(
+  version: String,
+  system: String,
+  systemVersion: String,
+  nrOfCpus: Double,
+  memory: Long,
+  diskSpace: Long,
+  roles: Seq[String],
+  bundleName: String,
+  compatibilityVersion: String,
+  tags: Seq[String],
+  annotations: Option[ConfigObject],
+  components: Map[String, BundleDescriptor.Component]
+)
+

--- a/scala-conductr-client-lib/src/main/scala/com/typesafe/conductr/clientlib/scala/models/BundleGetDescriptorResult.scala
+++ b/scala-conductr-client-lib/src/main/scala/com/typesafe/conductr/clientlib/scala/models/BundleGetDescriptorResult.scala
@@ -1,0 +1,30 @@
+package com.typesafe.conductr.clientlib.scala.models
+
+import com.typesafe.config.ConfigObject
+
+/**
+ * HTTP result for retrieving bundle descriptor.
+ */
+sealed trait BundleGetDescriptorResult
+
+/**
+ * Represents a HTTP success result for retrieving bundle descriptor.
+ *
+ * @param bundleDescriptor the bundle descriptor of the requested bundle.
+ */
+final case class BundleDescriptorGetSuccess(bundleDescriptor: BundleDescriptor) extends BundleGetDescriptorResult
+
+/**
+ * Represents a HTTP success result for retrieving bundle descriptor.
+ *
+ * @param config the bundle descriptor of the requested bundle in [[ConfigObject]] form.
+ */
+final case class BundleDescriptorGetConfigSuccess(config: ConfigObject) extends BundleGetDescriptorResult
+
+/**
+ * Represents a HTTP failure result for retrieving bundle descriptor.
+ *
+ * @param code The HTTP status code
+ * @param error The error message
+ */
+final case class BundleDescriptorGetFailure(code: Int, error: String) extends HttpFailure with BundleGetDescriptorResult

--- a/scala-conductr-client-lib/src/main/scala/com/typesafe/conductr/clientlib/scala/models/RequestAcl.scala
+++ b/scala-conductr-client-lib/src/main/scala/com/typesafe/conductr/clientlib/scala/models/RequestAcl.scala
@@ -3,4 +3,4 @@ package com.typesafe.conductr.clientlib.scala.models
 /**
  * Represents declaration of request mappings for a given endpoint.
  */
-case class RequestAcl(protocolFamilyRequestMappings: Set[ProtocolFamilyRequestMappings])
+case class RequestAcl(protocolFamilyRequestMappings: Seq[ProtocolFamilyRequestMappings])

--- a/scala-conductr-client-lib/src/main/scala/com/typesafe/conductr/clientlib/scala/models/RequestMapping.scala
+++ b/scala-conductr-client-lib/src/main/scala/com/typesafe/conductr/clientlib/scala/models/RequestMapping.scala
@@ -57,6 +57,7 @@ case class UdpRequestMapping(port: Int) extends RequestMapping
  */
 trait ProtocolFamilyRequestMappings {
   type Mapping <: RequestMapping
+  def protocolFamily: String
   def requestMappings: Iterable[Mapping]
 }
 
@@ -65,18 +66,21 @@ trait ProtocolFamilyRequestMappings {
  */
 case class HttpFamilyRequestMappings(requestMappings: Seq[HttpRequestMapping]) extends ProtocolFamilyRequestMappings {
   override type Mapping = HttpRequestMapping
+  val protocolFamily = "http"
 }
 
 /**
  * Base type which represents request mapping for a TCP protocol family.
  */
-case class TcpFamilyRequestMappings(requestMappings: Set[TcpRequestMapping]) extends ProtocolFamilyRequestMappings {
+case class TcpFamilyRequestMappings(requestMappings: Seq[TcpRequestMapping]) extends ProtocolFamilyRequestMappings {
   override type Mapping = TcpRequestMapping
+  val protocolFamily = "tcp"
 }
 
 /**
  * Base type which represents request mapping for a UDP protocol family.
  */
-case class UdpFamilyRequestMappings(requestMappings: Set[UdpRequestMapping]) extends ProtocolFamilyRequestMappings {
+case class UdpFamilyRequestMappings(requestMappings: Seq[UdpRequestMapping]) extends ProtocolFamilyRequestMappings {
   override type Mapping = UdpRequestMapping
+  val protocolFamily = "udp"
 }

--- a/scala-conductr-client-lib/src/test/scala/com/typesafe/conductr/clientlib/scala/models/BundleDescriptorSpec.scala
+++ b/scala-conductr-client-lib/src/test/scala/com/typesafe/conductr/clientlib/scala/models/BundleDescriptorSpec.scala
@@ -1,0 +1,330 @@
+package com.typesafe.conductr.clientlib.scala.models
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.{ Matchers, WordSpec }
+
+import scala.collection.immutable.Seq
+
+object BundleDescriptorSpec {
+  object WithoutTagsDashed {
+    val hocon =
+      """
+        |compatibility-version="1"
+        |components {
+        |  eslite {
+        |    description = eslite
+        |    endpoints {
+        |      akka-remote {
+        |        bind-port = 0
+        |        bind-protocol = tcp
+        |        services = []
+        |      }
+        |      es {
+        |        bind-port = 0
+        |        bind-protocol = http
+        |        service-name = elastic-search
+        |        services = []
+        |      }
+        |    }
+        |    file-system-type = universal
+        |    start-command = [
+        |      "eslite/bin/eslite",
+        |      "-J-Xms134217728",
+        |      "-J-Xmx134217728",
+        |      "-Dhttp.address=$ES_BIND_IP",
+        |      "-Dhttp.port=$ES_BIND_PORT",
+        |      "-Dplay.crypto.secret=65736c697465"
+        |    ]
+        |  }
+        |}
+        |disk-space = 200000000
+        |memory = 402653184
+        |name = eslite
+        |nr-of-cpus = 0.1
+        |roles = [elasticsearch]
+        |system = eslite
+        |system-version = "1"
+        |version = "1"
+      """.stripMargin
+
+    val bundleDescriptor = BundleDescriptor(
+      version = "1",
+      system = "eslite",
+      systemVersion = "1",
+      nrOfCpus = 0.1,
+      memory = 402653184L,
+      diskSpace = 200000000L,
+      roles = Seq("elasticsearch"),
+      bundleName = "eslite",
+      compatibilityVersion = "1",
+      tags = Seq.empty,
+      annotations = None,
+      components = Map(
+        "eslite" -> new BundleDescriptor.Component(
+          "eslite",
+          BundleDescriptor.Component.FileSystemType.Universal,
+          Seq(
+            "eslite/bin/eslite",
+            "-J-Xms134217728",
+            "-J-Xmx134217728",
+            "-Dhttp.address=$ES_BIND_IP",
+            "-Dhttp.port=$ES_BIND_PORT",
+            "-Dplay.crypto.secret=65736c697465"
+          ),
+          Map(
+            "akka-remote" -> BundleDescriptor.Component.Endpoint("tcp", 0, None, Seq.empty),
+            "es" -> BundleDescriptor.Component.Endpoint("http", 0, Some("elastic-search"), Seq.empty)
+          )
+        )
+      )
+    )
+  }
+
+  object WithoutTags {
+    val hocon =
+      """
+        |compatibilityVersion="1"
+        |components {
+        |  eslite {
+        |    description = eslite
+        |    endpoints {
+        |      akka-remote {
+        |        bind-port = 0
+        |        bind-protocol = tcp
+        |        services = []
+        |      }
+        |      es {
+        |        bind-port = 0
+        |        bind-protocol = http
+        |        service-name = elastic-search
+        |        services = []
+        |      }
+        |    }
+        |    file-system-type = universal
+        |    start-command = [
+        |      "eslite/bin/eslite",
+        |      "-J-Xms134217728",
+        |      "-J-Xmx134217728",
+        |      "-Dhttp.address=$ES_BIND_IP",
+        |      "-Dhttp.port=$ES_BIND_PORT",
+        |      "-Dplay.crypto.secret=65736c697465"
+        |    ]
+        |  }
+        |}
+        |diskSpace = 200000000
+        |memory = 402653184
+        |name = eslite
+        |nrOfCpus = 0.1
+        |roles = [elasticsearch]
+        |system = eslite
+        |systemVersion = "1"
+        |version = "1"
+      """.stripMargin
+
+    val bundleDescriptor = BundleDescriptor(
+      version = "1",
+      system = "eslite",
+      systemVersion = "1",
+      nrOfCpus = 0.1,
+      memory = 402653184L,
+      diskSpace = 200000000L,
+      roles = Seq("elasticsearch"),
+      bundleName = "eslite",
+      compatibilityVersion = "1",
+      tags = Seq.empty,
+      annotations = None,
+      components = Map(
+        "eslite" -> new BundleDescriptor.Component(
+          "eslite",
+          BundleDescriptor.Component.FileSystemType.Universal,
+          Seq(
+            "eslite/bin/eslite",
+            "-J-Xms134217728",
+            "-J-Xmx134217728",
+            "-Dhttp.address=$ES_BIND_IP",
+            "-Dhttp.port=$ES_BIND_PORT",
+            "-Dplay.crypto.secret=65736c697465"
+          ),
+          Map(
+            "akka-remote" -> BundleDescriptor.Component.Endpoint("tcp", 0, None, Seq.empty),
+            "es" -> BundleDescriptor.Component.Endpoint("http", 0, Some("elastic-search"), Seq.empty)
+          )
+        )
+      )
+    )
+  }
+
+  object WithTags {
+    val hocon =
+      """
+        |compatibilityVersion="1"
+        |components {
+        |  eslite {
+        |    description = eslite
+        |    endpoints {
+        |      akka-remote {
+        |        bind-port = 0
+        |        bind-protocol = tcp
+        |        services = []
+        |      }
+        |      es {
+        |        bind-port = 0
+        |        bind-protocol = http
+        |        service-name = elastic-search
+        |        services = []
+        |      }
+        |    }
+        |    file-system-type = universal
+        |    start-command = [
+        |      "eslite/bin/eslite",
+        |      "-J-Xms134217728",
+        |      "-J-Xmx134217728",
+        |      "-Dhttp.address=$ES_BIND_IP",
+        |      "-Dhttp.port=$ES_BIND_PORT",
+        |      "-Dplay.crypto.secret=65736c697465"
+        |    ]
+        |  }
+        |}
+        |diskSpace = 200000000
+        |memory = 402653184
+        |name = eslite
+        |nrOfCpus = 0.1
+        |roles = [elasticsearch]
+        |system = eslite
+        |systemVersion = "1"
+        |version = "1"
+        |tags = ["1.5.1", "non-prod"]
+      """.stripMargin
+
+    val bundleDescriptor = BundleDescriptor(
+      version = "1",
+      system = "eslite",
+      systemVersion = "1",
+      nrOfCpus = 0.1,
+      memory = 402653184L,
+      diskSpace = 200000000L,
+      roles = Seq("elasticsearch"),
+      bundleName = "eslite",
+      compatibilityVersion = "1",
+      tags = Seq("1.5.1", "non-prod"),
+      annotations = None,
+      components = Map(
+        "eslite" -> new BundleDescriptor.Component(
+          "eslite",
+          BundleDescriptor.Component.FileSystemType.Universal,
+          Seq(
+            "eslite/bin/eslite",
+            "-J-Xms134217728",
+            "-J-Xmx134217728",
+            "-Dhttp.address=$ES_BIND_IP",
+            "-Dhttp.port=$ES_BIND_PORT",
+            "-Dplay.crypto.secret=65736c697465"
+          ),
+          Map(
+            "akka-remote" -> BundleDescriptor.Component.Endpoint("tcp", 0, None, Seq.empty),
+            "es" -> BundleDescriptor.Component.Endpoint("http", 0, Some("elastic-search"), Seq.empty)
+          )
+        )
+      )
+    )
+  }
+
+  object WithAnnotationsDashed {
+    val hocon =
+      """
+        |compatibility-version="1"
+        |components {
+        |  eslite {
+        |    description = eslite
+        |    endpoints {
+        |      akka-remote {
+        |        bind-port = 0
+        |        bind-protocol = tcp
+        |        services = []
+        |      }
+        |      es {
+        |        bind-port = 0
+        |        bind-protocol = http
+        |        service-name = elastic-search
+        |        services = []
+        |      }
+        |    }
+        |    file-system-type = universal
+        |    start-command = [
+        |      "eslite/bin/eslite",
+        |      "-J-Xms134217728",
+        |      "-J-Xmx134217728",
+        |      "-Dhttp.address=$ES_BIND_IP",
+        |      "-Dhttp.port=$ES_BIND_PORT",
+        |      "-Dplay.crypto.secret=65736c697465"
+        |    ]
+        |  }
+        |}
+        |disk-space = 200000000
+        |memory = 402653184
+        |name = eslite
+        |nr-of-cpus = 0.1
+        |roles = [elasticsearch]
+        |system = eslite
+        |system-version = "1"
+        |version = "1"
+        |annotations = {
+        |  hey = there
+        |}
+      """.stripMargin
+
+    val bundleDescriptor = BundleDescriptor(
+      version = "1",
+      system = "eslite",
+      systemVersion = "1",
+      nrOfCpus = 0.1,
+      memory = 402653184L,
+      diskSpace = 200000000L,
+      roles = Seq("elasticsearch"),
+      bundleName = "eslite",
+      compatibilityVersion = "1",
+      tags = Seq.empty,
+      annotations = Some(ConfigFactory.parseString("hey = there").root()),
+      components = Map(
+        "eslite" -> new BundleDescriptor.Component(
+          "eslite",
+          BundleDescriptor.Component.FileSystemType.Universal,
+          Seq(
+            "eslite/bin/eslite",
+            "-J-Xms134217728",
+            "-J-Xmx134217728",
+            "-Dhttp.address=$ES_BIND_IP",
+            "-Dhttp.port=$ES_BIND_PORT",
+            "-Dplay.crypto.secret=65736c697465"
+          ),
+          Map(
+            "akka-remote" -> BundleDescriptor.Component.Endpoint("tcp", 0, None, Seq.empty),
+            "es" -> BundleDescriptor.Component.Endpoint("http", 0, Some("elastic-search"), Seq.empty)
+          )
+        )
+      )
+
+    )
+  }
+
+}
+
+class BundleDescriptorSpec extends WordSpec with Matchers {
+  import BundleDescriptorSpec._
+
+  "fromConfig" should {
+    Seq(
+      WithoutTagsDashed.hocon -> WithoutTagsDashed.bundleDescriptor -> "without tags + dashed config keys",
+      WithoutTags.hocon -> WithoutTags.bundleDescriptor -> "without tags",
+      WithTags.hocon -> WithTags.bundleDescriptor -> "with tags",
+      WithAnnotationsDashed.hocon -> WithAnnotationsDashed.bundleDescriptor -> "with annotations + dashed config keys"
+    ).foreach {
+        case ((hocon, expectedBundleDescriptor), scenario) =>
+          s"build BundleDescriptor $scenario" in {
+            val bundleDescriptorConfig = ConfigFactory.parseString(hocon).root()
+            BundleDescriptor.fromConfig(bundleDescriptorConfig) shouldBe expectedBundleDescriptor
+          }
+      }
+
+  }
+}


### PR DESCRIPTION
Also modify the `Set` declared within `RequestAcl` and its children to `Seq`. This is to ensure the order of the acls returned from ConductR is preserved.
