### PR TITLE
Now sets `X-Forwarded-For` header 

### DIFF
--- a/conductr-bundle-lib/src/main/java/com/typesafe/conductr/bundlelib/Env.java
+++ b/conductr-bundle-lib/src/main/java/com/typesafe/conductr/bundlelib/Env.java
@@ -8,9 +8,15 @@ public class Env {
     }
 
     /**
+     * The host IP that the current bundle is executing on
+     */
+    public static final String BUNDLE_HOST_IP = System.getenv("BUNDLE_HOST_IP");
+
+    /**
      * The bundle id of the current bundle
      */
     public static final String BUNDLE_ID = System.getenv("BUNDLE_ID");
+
 
     /**
      * The bundle name of the current bundle

--- a/conductr-bundle-lib/src/main/java/com/typesafe/conductr/bundlelib/StatusService.java
+++ b/conductr-bundle-lib/src/main/java/com/typesafe/conductr/bundlelib/StatusService.java
@@ -24,13 +24,15 @@ public class StatusService {
      */
     public static HttpPayload createSignalStartedPayload() throws IOException {
         if (isRunByConductR())
-            return createSignalStartedPayload(CONDUCTR_STATUS, BUNDLE_ID);
+            return createSignalStartedPayload(BUNDLE_HOST_IP, CONDUCTR_STATUS, BUNDLE_ID);
         else
             return null;
     }
 
-    static HttpPayload createSignalStartedPayload(String conductrControl, String bundleId) throws IOException {
+    static HttpPayload createSignalStartedPayload(String hostIp, String conductrControl, String bundleId) throws IOException {
         URL controlUrl = new URL(conductrControl + "/bundles/" + bundleId + "?isStarted=true");
-        return new HttpPayload(controlUrl, "PUT");
+
+        return new HttpPayload(controlUrl, "PUT")
+            .addRequestHeader("X-Forwarded-For", hostIp);
     }
 }


### PR DESCRIPTION
This PR sets `X-Forwarded-For` so that bundlelib works in containers or environments where the client IP may not reflect the correct host IP. `X-Forwarded-For` is the highest priority for Akka HTTP's `extractClientIp` and thus will override any `Remote-Address` headers that Akka HTTP client may set.