### PR TITLE
Introduce separate trait between the result of getBundleDescriptor and getBundleDescriptorConfig

### DIFF
--- a/akka24-conductr-client-lib/src/test/scala/com/typesafe/conductr/clientlib/akka/BundlesConnectorSpec.scala
+++ b/akka24-conductr-client-lib/src/test/scala/com/typesafe/conductr/clientlib/akka/BundlesConnectorSpec.scala
@@ -46,10 +46,10 @@ class BundlesConnectorSpec extends AkkaUnitTest {
         interval = 800.millis,
         tick = Seq(
           ServerSentEvent(s"${BundleFrontend.bundleId}", "bundleInstallationAdded"),
-          ServerSentEvent.heartbeat,
-          ServerSentEvent.heartbeat,
-          ServerSentEvent.heartbeat,
-          ServerSentEvent.heartbeat
+          ServerSentEvent.Heartbeat,
+          ServerSentEvent.Heartbeat,
+          ServerSentEvent.Heartbeat,
+          ServerSentEvent.Heartbeat
         )
       ).mapConcat(identity)
     )
@@ -97,10 +97,10 @@ class BundlesConnectorSpec extends AkkaUnitTest {
         interval = 800.millis,
         tick = Seq(
           ServerSentEvent(s"${BundleFrontend.bundleId}", "bundleInstallationAdded"),
-          ServerSentEvent.heartbeat,
-          ServerSentEvent.heartbeat,
-          ServerSentEvent.heartbeat,
-          ServerSentEvent.heartbeat
+          ServerSentEvent.Heartbeat,
+          ServerSentEvent.Heartbeat,
+          ServerSentEvent.Heartbeat,
+          ServerSentEvent.Heartbeat
         )
       ).mapConcat(identity)
     )

--- a/scala-conductr-client-lib/src/main/scala/com/typesafe/conductr/clientlib/scala/AbstractControlClient.scala
+++ b/scala-conductr-client-lib/src/main/scala/com/typesafe/conductr/clientlib/scala/AbstractControlClient.scala
@@ -66,7 +66,7 @@ abstract class AbstractControlClient(conductrAddress: URL) {
    *         - BundleDescriptorGetConfigSuccess if the bundle descriptor retrieval is successful. This object contains the actual bundle descriptor.
    *         - BundleDescriptorGetFailure if http request failed. The object contains the HTTP status code and error message.
    */
-  def getBundleDescriptorConfig(bundleId: BundleId)(implicit cc: CC): Future[BundleGetDescriptorResult]
+  def getBundleDescriptorConfig(bundleId: BundleId)(implicit cc: CC): Future[BundleGetDescriptorConfigResult]
 
   /**
    * Scale a loaded bundle to a number of instances.

--- a/scala-conductr-client-lib/src/main/scala/com/typesafe/conductr/clientlib/scala/models/BundleGetDescriptorConfigResult.scala
+++ b/scala-conductr-client-lib/src/main/scala/com/typesafe/conductr/clientlib/scala/models/BundleGetDescriptorConfigResult.scala
@@ -1,0 +1,23 @@
+package com.typesafe.conductr.clientlib.scala.models
+
+import com.typesafe.config.ConfigObject
+
+/**
+ * HTTP result for retrieving bundle descriptor config.
+ */
+sealed trait BundleGetDescriptorConfigResult
+
+/**
+ * Represents a HTTP success result for retrieving bundle descriptor config.
+ *
+ * @param config the bundle descriptor of the requested bundle in [[ConfigObject]] form.
+ */
+final case class BundleGetDescriptorConfigSuccess(config: ConfigObject) extends BundleGetDescriptorConfigResult
+
+/**
+ * Represents a HTTP failure result for retrieving bundle descriptor config.
+ *
+ * @param code The HTTP status code
+ * @param error The error message
+ */
+final case class BundleGetDescriptorConfigFailure(code: Int, error: String) extends HttpFailure with BundleGetDescriptorConfigResult

--- a/scala-conductr-client-lib/src/main/scala/com/typesafe/conductr/clientlib/scala/models/BundleGetDescriptorResult.scala
+++ b/scala-conductr-client-lib/src/main/scala/com/typesafe/conductr/clientlib/scala/models/BundleGetDescriptorResult.scala
@@ -1,7 +1,5 @@
 package com.typesafe.conductr.clientlib.scala.models
 
-import com.typesafe.config.ConfigObject
-
 /**
  * HTTP result for retrieving bundle descriptor.
  */
@@ -12,14 +10,7 @@ sealed trait BundleGetDescriptorResult
  *
  * @param bundleDescriptor the bundle descriptor of the requested bundle.
  */
-final case class BundleDescriptorGetSuccess(bundleDescriptor: BundleDescriptor) extends BundleGetDescriptorResult
-
-/**
- * Represents a HTTP success result for retrieving bundle descriptor.
- *
- * @param config the bundle descriptor of the requested bundle in [[ConfigObject]] form.
- */
-final case class BundleDescriptorGetConfigSuccess(config: ConfigObject) extends BundleGetDescriptorResult
+final case class BundleGetDescriptorSuccess(bundleDescriptor: BundleDescriptor) extends BundleGetDescriptorResult
 
 /**
  * Represents a HTTP failure result for retrieving bundle descriptor.
@@ -27,4 +18,4 @@ final case class BundleDescriptorGetConfigSuccess(config: ConfigObject) extends 
  * @param code The HTTP status code
  * @param error The error message
  */
-final case class BundleDescriptorGetFailure(code: Int, error: String) extends HttpFailure with BundleGetDescriptorResult
+final case class BundleGetDescriptorFailure(code: Int, error: String) extends HttpFailure with BundleGetDescriptorResult


### PR DESCRIPTION
Also ensure the naming of the class in the result returned by getBundleDescriptor is consistent with the base trait.