### PR TITLE
Add sonatype release step

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ lazy val root = project
 // When executing tests the projects are running sequentially.
 // If the tests of each project run sequentially or in parallel
 // is defined in the `build.sbt` of the individual project itself
-concurrentRestrictions in Global += Tags.limit(Tags.Test, 1)    
+concurrentRestrictions in Global += Tags.limit(Tags.Test, 1)
 
 
 // Base

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -43,8 +43,6 @@ object Build extends AutoPlugin {
         .setPreference(AlignSingleLineCaseStatements.MaxArrowIndent, 100)
         .setPreference(DoubleIndentClassDeclaration, true)
         .setPreference(PreserveDanglingCloseParenthesis, true),
-      // Sonatype settings
-      sonatypeProfileName := "com.typesafe",
       // Release settings
       releasePublishArtifactsAction := publishSigned.value,
       releaseCrossBuild := false,
@@ -58,6 +56,7 @@ object Build extends AutoPlugin {
         commitReleaseVersion,
         tagRelease,
         releaseStepCommandAndRemaining("+publishSigned"),
+        releaseStepCommandAndRemaining("sonatypeReleaseAll"),
         setNextVersion,
         commitNextVersion,
         pushChanges

--- a/sonatype.sbt
+++ b/sonatype.sbt
@@ -1,0 +1,1 @@
+sonatypeProfileName := "com.typesafe"


### PR DESCRIPTION
Adding `sonatypeReleaseAll` step after publishing the artifacts to sonatype. The `sonatypeProfileName` has been moved to `sonatype.sbt` so that sbt is picking up this value. The sonatype settings are not picked up in the `Build.scala`. If not specified, the sonatype profile name defaults to the organization name. This was the reason why the `sonatypeReleaseAll` command was not working prior to this PR.