### PR TITLE
Configuration Service Locator use case for Lagom

### DIFF
--- a/lagom1-java-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/lagom/javadsl/ServiceLocatorModule.scala
+++ b/lagom1-java-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/lagom/javadsl/ServiceLocatorModule.scala
@@ -2,21 +2,26 @@ package com.typesafe.conductr.bundlelib.lagom.javadsl
 
 import javax.inject.Singleton
 
-import com.lightbend.lagom.javadsl.api.ServiceLocator
+import com.lightbend.lagom.javadsl.api.{ ConfigurationServiceLocator, ServiceLocator }
 import com.typesafe.conductr.bundlelib.scala.Env
 import play.api.inject.{ Binding, Module }
-import play.api.{ Configuration, Environment }
+import play.api.{ Configuration, Environment, Mode }
 
 /**
- * This module binds the ServiceLocator interface from Lagom to the `ConductRServiceLocator`
- * The `ConductRServiceLocator` is only bound if the application has been started in `Prod` mode.
+ * This module binds the ServiceLocator interface from Lagom to the `ConductRServiceLocator` when
+ * running from ConductR. If not running from ConductR then Lagom's configuration service
+ * locator is used.
+ * The service locators are only bound if the application has been started in `Prod` mode.
  * In `Dev` mode the embedded service locator of Lagom is used.
  */
 class ServiceLocatorModule extends Module {
 
   override def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] =
-    if (Env.isRunByConductR)
-      Seq(bind[ServiceLocator].to[ConductRServiceLocator].in[Singleton])
+    if (environment.mode == Mode.Prod)
+      if (Env.isRunByConductR)
+        Seq(bind[ServiceLocator].to[ConductRServiceLocator].in[Singleton])
+      else
+        Seq(bind[ServiceLocator].to[ConfigurationServiceLocator].in[Singleton])
     else
       Seq.empty
 }


### PR DESCRIPTION
Prior to this commit there was no fallback URI for Lagom service locator lookups. The use-case for supporting the running of a Lagom service outside of ConductR, and outside of Lagom's development mode, was unsupported. This is an important use-case e.g. when running a Lagom service within Docker outside of ConductR.

This commit re-introduces the prod mode check that https://github.com/typesafehub/conductr-lib/pull/100 unwound, and additionally uses Lagom's configuration based service locator where ConductR hasn't invoked the bundle.