### PR TITLE
Make the usage of system names consistent

### DIFF
--- a/akka23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/EnvSpec.scala
+++ b/akka23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/EnvSpec.scala
@@ -5,9 +5,14 @@ import com.typesafe.config.ConfigException.Missing
 
 class EnvSpec extends AkkaUnitTest("EnvSpec") {
 
-  val config = Env.asConfig
+  val systemName = Env.mkSystemName("MyApp1")
+  val config = Env.asConfig(systemName)
 
   "The Env functionality in the library" should {
+    "provide the fallback system name" in {
+      systemName shouldBe "MyApp1"
+    }
+
     "return no seed properties when running in development mode" in {
       intercept[Missing](config.getString("akka.cluster.seed-nodes.0"))
       intercept[Missing](config.getString("akka.remote.netty.tcp.hostname"))

--- a/akka23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/EnvSpecWithEnvForHost.scala
+++ b/akka23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/EnvSpecWithEnvForHost.scala
@@ -4,7 +4,8 @@ import com.typesafe.conductr.lib.AkkaUnitTest
 
 class EnvSpecWithEnvForHost extends AkkaUnitTest("EnvSpecWithEnvForHost") {
 
-  val config = Env.asConfig
+  val systemName = Env.mkSystemName("MyApp1")
+  val config = Env.asConfig(systemName)
 
   "The Env functionality in the library" should {
     "return seed properties when running with no other seed nodes" in {

--- a/akka23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/EnvSpecWithEnvForOneOther.scala
+++ b/akka23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/EnvSpecWithEnvForOneOther.scala
@@ -5,7 +5,8 @@ import com.typesafe.config.ConfigException.Missing
 
 class EnvSpecWithEnvForOneOther extends AkkaUnitTest("EnvSpecWithEnvForOthers") {
 
-  val config = Env.asConfig
+  val systemName = Env.mkSystemName("MyApp1")
+  val config = Env.asConfig(systemName)
 
   "The Env functionality in the library" should {
     "return seed properties when running with one other seed node" in {

--- a/akka23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/EnvSpecWithEnvForOthers.scala
+++ b/akka23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/EnvSpecWithEnvForOthers.scala
@@ -5,7 +5,8 @@ import com.typesafe.config.ConfigException.Missing
 
 class EnvSpecWithEnvForOthers extends AkkaUnitTest("EnvSpecWithEnvForOthers") {
 
-  val config = Env.asConfig
+  val systemName = Env.mkSystemName("MyApp1")
+  val config = Env.asConfig(systemName)
 
   "The Env functionality in the library" should {
     "return seed properties when running with other seed nodes" in {

--- a/akka24-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/EnvSpec.scala
+++ b/akka24-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/EnvSpec.scala
@@ -5,9 +5,14 @@ import com.typesafe.config.ConfigException.Missing
 
 class EnvSpec extends AkkaUnitTest("EnvSpec") {
 
-  val config = Env.asConfig
+  val systemName = Env.mkSystemName("MyApp1")
+  val config = Env.asConfig(systemName)
 
   "The Env functionality in the library" should {
+    "provide the fallback system name" in {
+      systemName shouldBe "MyApp1"
+    }
+
     "return no seed properties when running in development mode" in {
       intercept[Missing](config.getString("akka.cluster.seed-nodes.0"))
       intercept[Missing](config.getString("akka.remote.netty.tcp.hostname"))

--- a/akka24-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/EnvSpecWithEnvForHost.scala
+++ b/akka24-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/EnvSpecWithEnvForHost.scala
@@ -4,7 +4,8 @@ import com.typesafe.conductr.lib.AkkaUnitTest
 
 class EnvSpecWithEnvForHost extends AkkaUnitTest("EnvSpecWithEnvForHost") {
 
-  val config = Env.asConfig
+  val systemName = Env.mkSystemName("MyApp1")
+  val config = Env.asConfig(systemName)
 
   "The Env functionality in the library" should {
     "return seed properties when running with no other seed nodes" in {

--- a/akka24-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/EnvSpecWithEnvForOneOther.scala
+++ b/akka24-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/EnvSpecWithEnvForOneOther.scala
@@ -5,7 +5,8 @@ import com.typesafe.config.ConfigException.Missing
 
 class EnvSpecWithEnvForOneOther extends AkkaUnitTest("EnvSpecWithEnvForOthers") {
 
-  val config = Env.asConfig
+  val systemName = Env.mkSystemName("MyApp1")
+  val config = Env.asConfig(systemName)
 
   "The Env functionality in the library" should {
     "return seed properties when running with one other seed node" in {

--- a/akka24-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/EnvSpecWithEnvForOthers.scala
+++ b/akka24-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/EnvSpecWithEnvForOthers.scala
@@ -5,7 +5,8 @@ import com.typesafe.config.ConfigException.Missing
 
 class EnvSpecWithEnvForOthers extends AkkaUnitTest("EnvSpecWithEnvForOthers") {
 
-  val config = Env.asConfig
+  val systemName = Env.mkSystemName("MyApp1")
+  val config = Env.asConfig(systemName)
 
   "The Env functionality in the library" should {
     "return seed properties when running with other seed nodes" in {

--- a/lagom1-java-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/lagom/javadsl/ConductRApplicationLoader.scala
+++ b/lagom1-java-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/lagom/javadsl/ConductRApplicationLoader.scala
@@ -14,10 +14,11 @@ import play.api.inject.guice.{ GuiceApplicationBuilder, GuiceApplicationLoader }
  */
 class ConductRApplicationLoader extends ApplicationLoader {
   def load(context: ApplicationLoader.Context): Application = {
-    val conductRConfig = Configuration(AkkaEnv.asConfig) ++ Configuration(PlayEnv.asConfig)
+    val systemName = AkkaEnv.mkSystemName("application")
+    val conductRConfig = Configuration(AkkaEnv.asConfig(systemName)) ++ Configuration(PlayEnv.asConfig(systemName))
     val newConfig = context.initialConfiguration ++ conductRConfig
     val newContext = context.copy(initialConfiguration = newConfig)
     val prodEnv = Environment.simple(mode = Mode.Prod)
-    new GuiceApplicationLoader(new GuiceApplicationBuilder(environment = prodEnv)).load(newContext)
+    new GuiceApplicationLoader(GuiceApplicationBuilder(environment = prodEnv)).load(newContext)
   }
 }

--- a/lagom1-scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/lagom/scaladsl/ConductRApplicationComponents.scala
+++ b/lagom1-scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/lagom/scaladsl/ConductRApplicationComponents.scala
@@ -27,7 +27,8 @@ trait ConductRApplicationComponents extends ConductRServiceLocatorComponents wit
   /**
    * The ConductR configuration.
    */
-  lazy val conductRConfiguration: Configuration = Configuration(AkkaEnv.asConfig) ++ Configuration(PlayEnv.asConfig)
+  lazy val systemName = AkkaEnv.mkSystemName("application")
+  lazy val conductRConfiguration: Configuration = Configuration(AkkaEnv.asConfig(systemName)) ++ Configuration(PlayEnv.asConfig(systemName))
 
   override def additionalConfiguration: AdditionalConfiguration = super.additionalConfiguration ++ conductRConfiguration
 }

--- a/play23-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/Env.scala
+++ b/play23-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/Env.scala
@@ -1,8 +1,8 @@
 package com.typesafe.conductr.bundlelib.play
 
+import com.typesafe.config.{ Config, ConfigFactory }
 import com.typesafe.conductr.bundlelib.akka.{ Env => AkkaEnv }
 
-import com.typesafe.config.{ ConfigFactory, Config }
 import scala.collection.JavaConverters._
 
 /**
@@ -11,17 +11,14 @@ import scala.collection.JavaConverters._
 object Env extends com.typesafe.conductr.bundlelib.scala.Env {
 
   /**
-   * Provides various Play related properties.
+   * See [[asConfig()]]
    */
   def asConfig: Config =
-    ConfigFactory.parseMap(playActorSystem.toMap.asJava)
+    asConfig(AkkaEnv.mkSystemName("application"))
 
-  private def playActorSystem: List[(String, String)] =
-    (for {
-      bundleSystem <- sys.env.get("BUNDLE_SYSTEM")
-      bundleSystemVersion <- sys.env.get("BUNDLE_SYSTEM_VERSION")
-    } yield {
-      val actorSystemName = s"${AkkaEnv.mkSystemId(bundleSystem)}-${AkkaEnv.mkSystemId(bundleSystemVersion)}"
-      "play.akka.actor-system" -> actorSystemName
-    }).toList
+  /**
+   * Provides various Play related properties.
+   */
+  def asConfig(systemName: String): Config =
+    ConfigFactory.parseMap(Map("play.akka.actor-system" -> systemName).asJava)
 }

--- a/play24-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/ConductRApplicationLoader.scala
+++ b/play24-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/ConductRApplicationLoader.scala
@@ -14,10 +14,11 @@ import play.api._
  */
 class ConductRApplicationLoader extends ApplicationLoader {
   def load(context: ApplicationLoader.Context): Application = {
-    val conductRConfig = Configuration(AkkaEnv.asConfig) ++ Configuration(PlayEnv.asConfig)
+    val systemName = AkkaEnv.mkSystemName("application")
+    val conductRConfig = Configuration(AkkaEnv.asConfig(systemName)) ++ Configuration(PlayEnv.asConfig(systemName))
     val newConfig = context.initialConfiguration ++ conductRConfig
     val newContext = context.copy(initialConfiguration = newConfig)
     val prodEnv = Environment.simple(mode = Mode.Prod)
-    (new GuiceApplicationLoader(new GuiceApplicationBuilder(environment = prodEnv))).load(newContext)
+    new GuiceApplicationLoader(new GuiceApplicationBuilder(environment = prodEnv)).load(newContext)
   }
 }

--- a/play24-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/Env.scala
+++ b/play24-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/Env.scala
@@ -1,8 +1,8 @@
 package com.typesafe.conductr.bundlelib.play
 
+import com.typesafe.config.{ Config, ConfigFactory }
 import com.typesafe.conductr.bundlelib.akka.{ Env => AkkaEnv }
 
-import com.typesafe.config.{ ConfigFactory, Config }
 import scala.collection.JavaConverters._
 
 /**
@@ -11,17 +11,14 @@ import scala.collection.JavaConverters._
 object Env extends com.typesafe.conductr.bundlelib.scala.Env {
 
   /**
-   * Provides various Play related properties.
+   * See [[asConfig()]]
    */
   def asConfig: Config =
-    ConfigFactory.parseMap(playActorSystem.toMap.asJava)
+    asConfig(AkkaEnv.mkSystemName("application"))
 
-  private def playActorSystem: List[(String, String)] =
-    (for {
-      bundleSystem <- sys.env.get("BUNDLE_SYSTEM")
-      bundleSystemVersion <- sys.env.get("BUNDLE_SYSTEM_VERSION")
-    } yield {
-      val actorSystemName = s"${AkkaEnv.mkSystemId(bundleSystem)}-${AkkaEnv.mkSystemId(bundleSystemVersion)}"
-      "play.akka.actor-system" -> actorSystemName
-    }).toList
+  /**
+   * Provides various Play related properties.
+   */
+  def asConfig(systemName: String): Config =
+    ConfigFactory.parseMap(Map("play.akka.actor-system" -> systemName).asJava)
 }

--- a/play25-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/api/ConductRApplicationLoader.scala
+++ b/play25-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/api/ConductRApplicationLoader.scala
@@ -14,11 +14,12 @@ import play.api.{ Application, ApplicationLoader, Configuration, Environment, Mo
  */
 class ConductRApplicationLoader extends ApplicationLoader {
   def load(context: ApplicationLoader.Context): Application = {
-    val conductRConfig = Configuration(AkkaEnv.asConfig) ++ Configuration(PlayEnv.asConfig)
+    val systemName = AkkaEnv.mkSystemName("application")
+    val conductRConfig = Configuration(AkkaEnv.asConfig(systemName)) ++ Configuration(PlayEnv.asConfig(systemName))
     val newConfig = context.initialConfiguration ++ conductRConfig
     val newContext = context.copy(initialConfiguration = newConfig)
     val prodEnv = Environment.simple(mode = Mode.Prod)
-    (new GuiceApplicationLoader(new GuiceApplicationBuilder(environment = prodEnv))).load(newContext)
+    new GuiceApplicationLoader(GuiceApplicationBuilder(environment = prodEnv)).load(newContext)
   }
 }
 
@@ -44,5 +45,6 @@ class ConductRApplicationLoader extends ApplicationLoader {
  */
 trait ConductRApplicationComponents extends BundlelibComponents with ConductRLifecycleComponents {
 
-  lazy val conductRConfiguration = Configuration(AkkaEnv.asConfig) ++ Configuration(PlayEnv.asConfig)
+  lazy val systemName = AkkaEnv.mkSystemName("application")
+  lazy val conductRConfiguration = Configuration(AkkaEnv.asConfig(systemName)) ++ Configuration(PlayEnv.asConfig)
 }

--- a/play25-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/api/Env.scala
+++ b/play25-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/api/Env.scala
@@ -11,17 +11,14 @@ import scala.collection.JavaConverters._
 object Env extends com.typesafe.conductr.bundlelib.scala.Env {
 
   /**
-   * Provides various Play related properties.
+   * See [[asConfig()]]
    */
   def asConfig: Config =
-    ConfigFactory.parseMap(playActorSystem.toMap.asJava)
+    asConfig(AkkaEnv.mkSystemName("application"))
 
-  private def playActorSystem: List[(String, String)] =
-    (for {
-      bundleSystem <- sys.env.get("BUNDLE_SYSTEM")
-      bundleSystemVersion <- sys.env.get("BUNDLE_SYSTEM_VERSION")
-    } yield {
-      val actorSystemName = s"${AkkaEnv.mkSystemId(bundleSystem)}-${AkkaEnv.mkSystemId(bundleSystemVersion)}"
-      "play.akka.actor-system" -> actorSystemName
-    }).toList
+  /**
+   * Provides various Play related properties.
+   */
+  def asConfig(systemName: String): Config =
+    ConfigFactory.parseMap(Map("play.akka.actor-system" -> systemName).asJava)
 }


### PR DESCRIPTION
This commit provides the ability to build a system name from Env vars when using the Akka APIs. We want to encourage users to use our API to build a system name, allowing them to fall back to a name of their choice when not using ConductR. Not using our API can result in making mistakes around using a system name that does not correspond to seed nodes, particularly when using Akka cluster.

I preserve backwards compatibility while deprecating the previous Env.asConfig API in order to encourage users to use the new API.

I also removed some 2.12 deprecations.

In addition to addressing the unit tests, I've tested the new library against the Akka cluster sample from the Akka team. Establishing an actor system is now cleaner and less error prone:

```scala
val systemName = Env.mkSystemName("ClusterSystem")
val config = Env.asConfig(systemName)
implicit val system = ActorSystem(systemName, config.withFallback(ConfigFactory.load()))
```

I've observed that I can still create an Akka cluster bundle and have it work on ConductR across 2 nodes.