### PR TITLE
Ensure akka bind properties are set

### DIFF
--- a/akka24-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/akka/Env.scala
+++ b/akka24-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/akka/Env.scala
@@ -68,8 +68,10 @@ object Env extends com.typesafe.conductr.bundlelib.scala.Env {
     }
     val hostname = sys.env.get("BUNDLE_HOST_IP").toList.map("akka.remote.netty.tcp.hostname" -> _)
     val port = sys.env.get(s"${akkaRemoteEndpointName}_HOST_PORT").toList.map("akka.remote.netty.tcp.port" -> _)
+    val internalHostname = sys.env.get(s"${akkaRemoteEndpointName}_BIND_IP").toList.map("akka.remote.netty.tcp.bind-hostname" -> _)
+    val internalPort = sys.env.get(s"${akkaRemoteEndpointName}_BIND_PORT").toList.map("akka.remote.netty.tcp.bind-port" -> _)
 
-    ConfigFactory.parseMap((akkaSeeds ++ hostname ++ port).toMap.asJava)
+    ConfigFactory.parseMap((akkaSeeds ++ hostname ++ port ++ internalHostname ++ internalPort).toMap.asJava)
   }
 
   /**


### PR DESCRIPTION
This PR ensures that we're setting `akka.remote.netty.tcp.bind-hostname` and `akka.remote.netty.tcp.bind-port`. We need to do this for situations where we're running inside docker containers, for instance chirper maven build via `runc` inside docker via Docker in OCI support.

I've manually tested this by publishing with `sbt publishM2` and configuring the chirper build as necessary. Prior to this change, it would fail to start due to a failure to bind the akka remote IP.

This section of Akka documentation is relevant: http://doc.akka.io/docs/akka/current/java/remoting.html#Akka_behind_NAT_or_in_a_Docker_container