### PR TITLE
Adds missing CircuitBreakersComponents to the cake

### DIFF
--- a/lagom1-scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/lagom/scaladsl/ConductRApplicationComponents.scala
+++ b/lagom1-scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/lagom/scaladsl/ConductRApplicationComponents.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorSystem
 import com.lightbend.lagom.internal.client.{ CircuitBreakerConfig, CircuitBreakerMetricsProviderImpl, CircuitBreakers }
 import com.lightbend.lagom.internal.spi.CircuitBreakerMetricsProvider
 import com.lightbend.lagom.scaladsl.api.{ AdditionalConfiguration, ProvidesAdditionalConfiguration, ServiceLocator }
-import com.lightbend.lagom.scaladsl.client.ConfigurationServiceLocator
+import com.lightbend.lagom.scaladsl.client.{ CircuitBreakerComponents, ConfigurationServiceLocator }
 import com.typesafe.conductr.bundlelib.akka.{ Env => AkkaEnv }
 import com.typesafe.conductr.bundlelib.play.api.{ BundlelibComponents, ConductRLifecycleComponents, Env => PlayEnv }
 import com.typesafe.conductr.bundlelib.scala.Env
@@ -36,7 +36,7 @@ trait ConductRApplicationComponents extends ConductRServiceLocatorComponents wit
 /**
  * Provides the ConductR service locator.
  */
-trait ConductRServiceLocatorComponents extends BundlelibComponents {
+trait ConductRServiceLocatorComponents extends BundlelibComponents with CircuitBreakerComponents {
   def actorSystem: ActorSystem
   def configuration: Configuration
 


### PR DESCRIPTION
Second attempt at fixing #147. 
Despite publishing locally I can't retest this with `sbt-conductr` so I'm in the blind as much as I was on #148. :-(
I tried bumping `sbt-conductr` dependency on [conductr-lib](https://github.com/typesafehub/sbt-conductr/blob/9b4d6b5c25890668daa15529774bc946293eb7bb/src/main/scala/com/lightbend/conductr/sbt/package.scala#L79-L79) to a localy publishd snapshot but it's not picked up. I'll try harder :-(