### PR TITLE
Play 2.6 Bundle Lib: append allow hosts

### DIFF
--- a/play26-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/api/ConductRApplicationLoader.scala
+++ b/play26-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/api/ConductRApplicationLoader.scala
@@ -14,9 +14,11 @@ import play.api.{ Application, ApplicationLoader, Configuration, Environment, Mo
  */
 class ConductRApplicationLoader extends ApplicationLoader {
   def load(context: ApplicationLoader.Context): Application = {
+    val existingConfig = context.initialConfiguration
+
     val systemName = AkkaEnv.mkSystemName("application")
-    val conductRConfig = Configuration(AkkaEnv.asConfig(systemName)) ++ Configuration(PlayEnv.asConfig(systemName))
-    val newConfig = context.initialConfiguration ++ conductRConfig
+    val conductRConfig = Configuration(AkkaEnv.asConfig(systemName)) ++ Configuration(PlayEnv.asConfig(systemName, existingConfig.underlying))
+    val newConfig = existingConfig ++ conductRConfig
     val prodEnv = Environment.simple(mode = Mode.Prod)
     // The logic below is the default GuiceApplicationLoader behavior, but
     // with a patched environment and config. We can't use the default

--- a/play26-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/api/Env.scala
+++ b/play26-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/api/Env.scala
@@ -9,6 +9,7 @@ import scala.collection.JavaConverters._
  * Provides functions to set up the Play environment in accordance with what ConductR provides.
  */
 object Env extends com.typesafe.conductr.bundlelib.scala.Env {
+  val PlayFilterHostsAllowed = "play.filters.hosts.allowed"
 
   /**
    * See [[asConfig()]]
@@ -16,14 +17,29 @@ object Env extends com.typesafe.conductr.bundlelib.scala.Env {
   def asConfig: Config =
     asConfig(AkkaEnv.mkSystemName("application"))
 
+  def asConfig(systemName: String): Config =
+    asConfig(systemName, existingConfig = None)
+
+  def asConfig(systemName: String, existingConfig: Config): Config =
+    asConfig(systemName, Some(existingConfig))
+
   /**
    * Provides various Play related properties.
    */
-  def asConfig(systemName: String): Config =
-    ConfigFactory.parseMap(
-      Map(
-      "play.akka.actor-system" -> systemName,
-      "play.filters.hosts.allowed.0" -> sys.env.getOrElse("BUNDLE_HOST_IP", "127.0.0.1")
-    ).asJava
-    )
+  def asConfig(systemName: String, existingConfig: Option[Config]): Config = {
+    val allowedHosts = existingConfig
+      .filter(_.hasPath(PlayFilterHostsAllowed))
+      .fold(Seq.empty[String])(_.getStringList(PlayFilterHostsAllowed).asScala)
+
+    val mergedConfigs = Map("play.akka.actor-system" -> systemName) ++
+      (allowedHosts :+ sys.env.getOrElse("BUNDLE_HOST_IP", "127.0.0.1"))
+      .zipWithIndex
+      .map {
+        case (host, index) => Map(s"$PlayFilterHostsAllowed.$index" -> host)
+      }
+      .reduce(_ ++ _)
+
+    ConfigFactory.parseMap(mergedConfigs.asJava)
+  }
+
 }

--- a/play26-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/api/EnvSpecWithEnv.scala
+++ b/play26-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/api/EnvSpecWithEnv.scala
@@ -1,6 +1,7 @@
 package com.typesafe.conductr.bundlelib.play.api
 
 import com.typesafe.conductr.lib.AkkaUnitTest
+import com.typesafe.config.ConfigFactory
 
 import scala.collection.JavaConverters._
 
@@ -12,6 +13,19 @@ class EnvSpecWithEnv extends AkkaUnitTest("EnvSpecWithEnvForHost") {
     "initialize the env like expected" in {
       config.getString("play.akka.actor-system") shouldBe "somesys-v1"
       config.getStringList("play.filters.hosts.allowed").asScala shouldBe List("1.1.1.1")
+    }
+
+    "merged the allowed hosts config" in {
+      val existing = ConfigFactory.parseString(
+        """
+          |play.filters.hosts.allowed = ["a.com", "b.com"]
+        """.stripMargin
+      )
+
+      val result = Env.asConfig("my-system", existing)
+
+      result.getString("play.akka.actor-system") shouldBe "my-system"
+      result.getStringList("play.filters.hosts.allowed").asScala shouldBe List("a.com", "b.com", "1.1.1.1")
     }
   }
 }


### PR DESCRIPTION
Obtain the reference to existing config, and append `BUNDLE_HOST_IP` to the list of allowed hosts