### PR TITLE
Ensure ConductRServiceLocatorComponents extends Lagom's CircuitBreakerComponents

### DIFF
--- a/lagom14-scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/lagom/scaladsl/ConductRApplicationComponents.scala
+++ b/lagom14-scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/lagom/scaladsl/ConductRApplicationComponents.scala
@@ -2,7 +2,7 @@ package com.typesafe.conductr.bundlelib.lagom.scaladsl
 
 import akka.actor.ActorSystem
 import com.lightbend.lagom.scaladsl.api.{ AdditionalConfiguration, ProvidesAdditionalConfiguration, ServiceLocator }
-import com.lightbend.lagom.scaladsl.client.{ CircuitBreakersPanel, ConfigurationServiceLocator, LagomServiceClientComponents }
+import com.lightbend.lagom.scaladsl.client.{ CircuitBreakerComponents, CircuitBreakersPanel, ConfigurationServiceLocator, LagomServiceClientComponents }
 import com.typesafe.conductr.bundlelib.akka.{ Env => AkkaEnv }
 import com.typesafe.conductr.bundlelib.play.api.{ BundlelibComponents, ConductRLifecycleComponents, Env => PlayEnv }
 import com.typesafe.conductr.bundlelib.scala.Env
@@ -34,11 +34,7 @@ trait ConductRApplicationComponents extends ConductRServiceLocatorComponents wit
 /**
  * Provides the ConductR service locator.
  */
-trait ConductRServiceLocatorComponents extends BundlelibComponents with LagomServiceClientComponents {
-  def actorSystem: ActorSystem
-  def circuitBreakersPanel: CircuitBreakersPanel
-  def configuration: Configuration
-
+trait ConductRServiceLocatorComponents extends BundlelibComponents with LagomServiceClientComponents with CircuitBreakerComponents {
   lazy val serviceLocator: ServiceLocator =
     if (Env.isRunByConductR)
       new ConductRServiceLocator(conductRLocationSevice, conductRCacheLike, circuitBreakersPanel)(executionContext)

--- a/lagom14-scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/lagom/scaladsl/ConductRServiceLocatorSpecWithEnv.scala
+++ b/lagom14-scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/lagom/scaladsl/ConductRServiceLocatorSpecWithEnv.scala
@@ -2,6 +2,7 @@ package com.typesafe.conductr.bundlelib.lagom.scaladsl
 
 import java.net.{ InetSocketAddress, URI => JavaURI }
 
+import akka.NotUsed
 import akka.actor._
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.headers.{ CacheDirectives, Location, `Cache-Control` }
@@ -11,9 +12,11 @@ import akka.stream.ActorMaterializer
 import akka.testkit.TestProbe
 import com.lightbend.lagom.internal.client.CircuitBreakerMetricsProviderImpl
 import com.lightbend.lagom.internal.spi.CircuitBreakerMetricsProvider
-import com.lightbend.lagom.scaladsl.api.{ Descriptor, Service, ServiceAcl, ServiceInfo }
+import com.lightbend.lagom.scaladsl.api.ServiceLocator.NoServiceLocator
+import com.lightbend.lagom.scaladsl.api.transport.Method
+import com.lightbend.lagom.scaladsl.api.{ Descriptor, Service, ServiceAcl, ServiceCall, ServiceInfo }
 import com.lightbend.lagom.scaladsl.client.CircuitBreakerComponents
-import com.lightbend.lagom.scaladsl.server.{ LagomApplication, LagomApplicationContext }
+import com.lightbend.lagom.scaladsl.server.{ LagomApplication, LagomApplicationContext, LagomApplicationLoader }
 import com.typesafe.conductr.bundlelib.play.api.{ Env => PlayEnv }
 import com.typesafe.conductr.bundlelib.scala.{ URI, URL }
 import com.typesafe.conductr.lib.AkkaUnitTestWithFixture
@@ -22,7 +25,7 @@ import play.api.routing.Router
 import play.api.test.Helpers._
 
 import scala.collection.immutable
-import scala.concurrent.Await
+import scala.concurrent.{ Await, Future }
 import scala.util.{ Failure, Success }
 
 object ConductRServiceLocatorSpecWithEnv {
@@ -78,6 +81,43 @@ class ConductRServiceLocatorSpecWithEnv extends AkkaUnitTestWithFixture("Conduct
           Await.result(service, timeout.duration) shouldBe Some(serviceUri)
         }
       }
+    }
+
+    "be able to be mixed in into a lagom application" in { _ =>
+      // Don't be surprised if you see all these Lagom definitions declared here that does nothing.
+      // This is intentional.
+      // We have these declarations to assert that the application will compile successfully by mixing in
+      // ConductRApplicationComponents.
+      // This test is put in place as there were changes in the Lagom 1.4 API that will break user's code compilation
+      // due to ConductRApplicationComponents not extending CircuitBreakersComponent.
+      // Reference: https://github.com/typesafehub/conductr-lib/pull/162#issuecomment-351240570
+
+      trait HelloService extends Service {
+        def hello(input: String): ServiceCall[NotUsed, String]
+        override final def descriptor: Descriptor = {
+          import Service._
+          named("hello")
+            .withCalls(restCall(Method.GET, "/hello/:text", hello _))
+            .withAutoAcl(true)
+        }
+      }
+
+      class HelloServiceImpl extends HelloService {
+        override def hello(input: String): ServiceCall[NotUsed, String] = ServiceCall(_ => Future.successful(input.toUpperCase))
+      }
+
+      abstract class HelloApplication(context: LagomApplicationContext) extends LagomApplication(context) with AhcWSComponents {
+        override def lagomServer = serverFor[HelloService](new HelloServiceImpl)
+      }
+
+      class HelloApplicationLoader extends LagomApplicationLoader {
+        override def load(context: LagomApplicationContext) =
+          new HelloApplication(context) with ConductRApplicationComponents
+        override def loadDevMode(context: LagomApplicationContext) =
+          new HelloApplication(context) with ConductRApplicationComponents
+        override def describeService = Some(readDescriptor[HelloService])
+      }
+
     }
   }
 


### PR DESCRIPTION
This is to ensure the user API usage documented in the following URL still holds true and compiles successfully:

https://www.lagomframework.com/documentation/1.4.x/scala/ConductR.html

A test is added to ensure a successful compilation according to the API usage documented above.